### PR TITLE
Test login and redirect behavior for logged in/out users against /settings page

### DIFF
--- a/cypress/integration/productionTests/privatePaths/render/settings/development.spec.ts
+++ b/cypress/integration/productionTests/privatePaths/render/settings/development.spec.ts
@@ -1,0 +1,45 @@
+import { runTestsForDevices } from "../../../../utils";
+import { macbook15ForAppLayout } from "../../../../utils/devices";
+import { newExpectation, newShouldArgs } from "../../../../utils/helpers";
+
+const pageName = "Settings page for logged out user";
+const currentPage = "/settings/development";
+const isLocalDoltHub = !!Cypress.env("LOCAL_DOLTHUB");
+const loggedIn = true;
+
+describe(`${pageName} renders expected components on different devices`, () => {
+  const testsForLocalDoltHub = [
+    newExpectation(
+      "should render Development Page on localhost",
+      "[data-cy=settings-development]",
+      newShouldArgs(
+        "be.visible.and.contain",
+        "Would you like to delete all your repositories?",
+      ),
+    ),
+    newExpectation(
+      "should not render 404 for Development Page on localhost",
+      "[data-cy=404-page]",
+      newShouldArgs("not.exist"),
+    ),
+  ];
+
+  const testsForDevProd = [
+    newExpectation(
+      "should render 404 on dev and prod for Development Page",
+      "[data-cy=404-page]",
+      newShouldArgs("be.visible.and.contain", "Page not found"),
+    ),
+    newExpectation(
+      "should not render Development Page on dev and prod",
+      "[data-cy=settings-development]",
+      newShouldArgs("not.exist"),
+    ),
+  ];
+
+  const tests = isLocalDoltHub ? testsForLocalDoltHub : testsForDevProd;
+
+  const devices = [macbook15ForAppLayout(pageName, tests, true, loggedIn)];
+
+  runTestsForDevices({ currentPage, devices });
+});

--- a/cypress/integration/productionTests/privatePaths/render/settings/index.spec.ts
+++ b/cypress/integration/productionTests/privatePaths/render/settings/index.spec.ts
@@ -4,10 +4,12 @@ import { newExpectation, newShouldArgs } from "../../../../utils/helpers";
 
 const pageName = "Settings";
 const currentPage = "/settings";
+const isLocalDoltHub = !!Cypress.env("LOCAL_DOLTHUB");
+
 const loggedIn = true;
 
 describe(`${pageName} renders expected components on different devices`, () => {
-  const tests = [
+  const navLinkTests = [
     newExpectation(
       "should render Settings header",
       "[data-cy=settings-header]",
@@ -49,16 +51,19 @@ describe(`${pageName} renders expected components on different devices`, () => {
       newShouldArgs("not.exist"),
       false,
     ),
-    // The Development tab is expected to render ONLY in a local environment.
-    // Because this test (and all on this page) require a signin, this test fails on localhost before it even reaches the assertion.
     newExpectation(
       "should not render Development link in dev or prod",
       "[data-cy=settings-development-section-link]",
-      newShouldArgs("not.exist"),
+      isLocalDoltHub ? newShouldArgs("be.visible") : newShouldArgs("not.exist"),
       false,
     ),
   ];
 
-  const devices = desktopDevicesForAppLayout(pageName, tests, true, loggedIn);
+  const devices = desktopDevicesForAppLayout(
+    pageName,
+    navLinkTests,
+    true,
+    loggedIn,
+  );
   runTestsForDevices({ currentPage, devices });
 });

--- a/cypress/integration/productionTests/privatePaths/render/settings/index.spec.ts
+++ b/cypress/integration/productionTests/privatePaths/render/settings/index.spec.ts
@@ -1,0 +1,20 @@
+import { runTestsForDevices } from "../../../../utils";
+import { desktopDevicesForAppLayout } from "../../../../utils/devices";
+import { newExpectation, newShouldArgs } from "../../../../utils/helpers";
+
+const pageName = "Settings";
+const currentPage = "/settings";
+const loggedIn = true;
+
+describe(`${pageName} renders expected components on different devices`, () => {
+  const tests = [
+    newExpectation(
+      "should render Settings header",
+      "[data-cy=settings-header]",
+      newShouldArgs("be.visible"),
+    ),
+  ];
+
+  const devices = desktopDevicesForAppLayout(pageName, tests, false, loggedIn);
+  runTestsForDevices({ currentPage, devices });
+});

--- a/cypress/integration/productionTests/privatePaths/render/settings/index.spec.ts
+++ b/cypress/integration/productionTests/privatePaths/render/settings/index.spec.ts
@@ -13,8 +13,52 @@ describe(`${pageName} renders expected components on different devices`, () => {
       "[data-cy=settings-header]",
       newShouldArgs("be.visible"),
     ),
+    newExpectation(
+      "should render Settings Profile link",
+      "[data-cy=settings-profile-section-link]",
+      newShouldArgs("be.visible"),
+    ),
+    newExpectation(
+      "should render Settings Email link",
+      "[data-cy=settings-email-section-link]",
+      newShouldArgs("be.visible"),
+    ),
+    newExpectation(
+      "should render Settings Credentials link",
+      "[data-cy=settings-credentials-section-link]",
+      newShouldArgs("be.visible"),
+    ),
+    newExpectation(
+      "should render Settings Repositories link",
+      "[data-cy=settings-repositories-section-link]",
+      newShouldArgs("be.visible"),
+    ),
+    newExpectation(
+      "should render Settings Organizations link",
+      "[data-cy=settings-organizations-section-link]",
+      newShouldArgs("be.visible"),
+    ),
+    newExpectation(
+      "should render Settings Billing link",
+      "[data-cy=settings-billing-section-link]",
+      newShouldArgs("be.visible"),
+    ),
+    newExpectation(
+      "should not render Payment History link for standard Cypress Testing account with no payment plan/history",
+      "[data-cy=settings-payment-history-section-link]",
+      newShouldArgs("not.exist"),
+      false,
+    ),
+    // The Development tab is expected to render ONLY in a local environment.
+    // Because this test (and all on this page) require a signin, this test fails on localhost before it even reaches the assertion.
+    newExpectation(
+      "should not render Development link in dev or prod",
+      "[data-cy=settings-development-section-link]",
+      newShouldArgs("not.exist"),
+      false,
+    ),
   ];
 
-  const devices = desktopDevicesForAppLayout(pageName, tests, false, loggedIn);
+  const devices = desktopDevicesForAppLayout(pageName, tests, true, loggedIn);
   runTestsForDevices({ currentPage, devices });
 });

--- a/cypress/integration/productionTests/privatePaths/render/settings/index.spec.ts
+++ b/cypress/integration/productionTests/privatePaths/render/settings/index.spec.ts
@@ -41,6 +41,11 @@ describe(`${pageName} renders expected components on different devices`, () => {
       newShouldArgs("be.visible"),
     ),
     newExpectation(
+      "should render Settings Security link for user who signed up with username/email (cypresstesting)",
+      "[data-cy=settings-security-section-link]",
+      newShouldArgs("be.visible"),
+    ),
+    newExpectation(
       "should render Settings Billing link",
       "[data-cy=settings-billing-section-link]",
       newShouldArgs("be.visible"),

--- a/cypress/integration/productionTests/publicPaths/render/settings/index.spec.ts
+++ b/cypress/integration/productionTests/publicPaths/render/settings/index.spec.ts
@@ -1,0 +1,22 @@
+import { runTestsForDevices } from "../../../../utils";
+import { macbook15ForAppLayout } from "../../../../utils/devices";
+import { newExpectationWithRedirect, newShouldArgs } from "../../../../utils/helpers";
+
+const pageName = "Settings page for logged out user";
+const currentPage = "/settings"
+
+describe(`${pageName} redirects to the /signin page for logged out users on different devices`, () => {
+  const tests = [
+    newExpectationWithRedirect(
+      "should be redirected to signin page",
+      "[data-cy=signup-why-join]",
+      newShouldArgs("be.visible.and.contain", "Why join DoltHub?"),
+      false,
+      "settings"
+    ),
+  ];
+
+  const devices = [macbook15ForAppLayout(pageName, tests)];
+
+  runTestsForDevices({ currentPage, devices });
+});

--- a/cypress/integration/productionTests/publicPaths/render/settings/index.spec.ts
+++ b/cypress/integration/productionTests/publicPaths/render/settings/index.spec.ts
@@ -1,18 +1,21 @@
 import { runTestsForDevices } from "../../../../utils";
 import { macbook15ForAppLayout } from "../../../../utils/devices";
-import { newExpectation, newShouldArgs } from "../../../../utils/helpers";
+import {
+  newExpectationWithURL,
+  newShouldArgs,
+} from "../../../../utils/helpers";
 
 const pageName = "Settings page for logged out user";
 const currentPage = "/settings";
 
 describe(`${pageName} redirects to the /signin page for logged out users on different devices`, () => {
-  // TODO: Check that location search terms = "settings"
   const tests = [
-    newExpectation(
-      "should be redirected to signin page",
+    newExpectationWithURL(
+      "should be redirected to signin page and preserve redirect info",
       "[data-cy=signup-why-join]",
       newShouldArgs("be.visible.and.contain", "Why join DoltHub?"),
       false,
+      "/signin?redirect=%2Fsettings",
     ),
   ];
 

--- a/cypress/integration/productionTests/publicPaths/render/settings/index.spec.ts
+++ b/cypress/integration/productionTests/publicPaths/render/settings/index.spec.ts
@@ -1,21 +1,17 @@
 import { runTestsForDevices } from "../../../../utils";
 import { macbook15ForAppLayout } from "../../../../utils/devices";
-import {
-  newExpectationWithRedirect,
-  newShouldArgs,
-} from "../../../../utils/helpers";
+import { newExpectation, newShouldArgs } from "../../../../utils/helpers";
 
 const pageName = "Settings page for logged out user";
 const currentPage = "/settings";
 
 describe(`${pageName} redirects to the /signin page for logged out users on different devices`, () => {
   const tests = [
-    newExpectationWithRedirect(
+    newExpectation(
       "should be redirected to signin page",
       "[data-cy=signup-why-join]",
       newShouldArgs("be.visible.and.contain", "Why join DoltHub?"),
       false,
-      "settings",
     ),
   ];
 

--- a/cypress/integration/productionTests/publicPaths/render/settings/index.spec.ts
+++ b/cypress/integration/productionTests/publicPaths/render/settings/index.spec.ts
@@ -6,6 +6,7 @@ const pageName = "Settings page for logged out user";
 const currentPage = "/settings";
 
 describe(`${pageName} redirects to the /signin page for logged out users on different devices`, () => {
+  // TODO: Check that location search terms = "settings"
   const tests = [
     newExpectation(
       "should be redirected to signin page",

--- a/cypress/integration/productionTests/publicPaths/render/settings/index.spec.ts
+++ b/cypress/integration/productionTests/publicPaths/render/settings/index.spec.ts
@@ -1,9 +1,12 @@
 import { runTestsForDevices } from "../../../../utils";
 import { macbook15ForAppLayout } from "../../../../utils/devices";
-import { newExpectationWithRedirect, newShouldArgs } from "../../../../utils/helpers";
+import {
+  newExpectationWithRedirect,
+  newShouldArgs,
+} from "../../../../utils/helpers";
 
 const pageName = "Settings page for logged out user";
-const currentPage = "/settings"
+const currentPage = "/settings";
 
 describe(`${pageName} redirects to the /signin page for logged out users on different devices`, () => {
   const tests = [
@@ -12,7 +15,7 @@ describe(`${pageName} redirects to the /signin page for logged out users on diff
       "[data-cy=signup-why-join]",
       newShouldArgs("be.visible.and.contain", "Why join DoltHub?"),
       false,
-      "settings"
+      "settings",
     ),
   ];
 

--- a/cypress/integration/productionTests/publicPaths/render/settings/index.spec.ts
+++ b/cypress/integration/productionTests/publicPaths/render/settings/index.spec.ts
@@ -14,7 +14,6 @@ describe(`${pageName} redirects to the /signin page for logged out users on diff
       "should be redirected to signin page and preserve redirect info",
       "[data-cy=signup-why-join]",
       newShouldArgs("be.visible.and.contain", "Why join DoltHub?"),
-      false,
       "/signin?redirect=%2Fsettings",
     ),
   ];

--- a/cypress/integration/productionTests/publicPaths/render/signin/index.spec.ts
+++ b/cypress/integration/productionTests/publicPaths/render/signin/index.spec.ts
@@ -1,9 +1,13 @@
 import { runTestsForDevices } from "../../../../utils";
-import { allDevicesDiffTestsForSignedOut } from "../../../../utils/devices";
+import {
+  allDevicesDiffTestsForSignedOut,
+  macbook15,
+} from "../../../../utils/devices";
 import {
   newClickFlow,
   newExpectation,
   newExpectationWithClickFlows,
+  newExpectationWithRedirect,
   newShouldArgs,
   scrollToPosition,
 } from "../../../../utils/helpers";
@@ -11,6 +15,7 @@ import { ClickFlow } from "../../../../utils/types";
 
 const pageName = "Sign in page";
 const currentPage = "/signin";
+const currentPageWithRedirect = "/signin?redirect=%2Fsettings";
 
 describe(`${pageName} renders expected components on different devices`, () => {
   const beVisible = newShouldArgs("be.visible");
@@ -157,6 +162,22 @@ describe(`${pageName} renders expected components on different devices`, () => {
     tests,
     mobileTests,
   );
-
   runTestsForDevices({ currentPage, devices });
+
+  // Test that a signin URL with search params redirects to the expected page after signin.
+  const redirectTests = [
+    newExpectationWithRedirect(
+      "should redirect to /settings page after sign in",
+      "[data-cy=settings-header]",
+      beVisible,
+      false,
+      "settings",
+    ),
+  ];
+
+  const devicesForRedirectLink = [macbook15(pageName, redirectTests, false)];
+  runTestsForDevices({
+    currentPage: currentPageWithRedirect,
+    devices: devicesForRedirectLink,
+  });
 });

--- a/cypress/integration/productionTests/publicPaths/render/signin/index.spec.ts
+++ b/cypress/integration/productionTests/publicPaths/render/signin/index.spec.ts
@@ -1,13 +1,9 @@
 import { runTestsForDevices } from "../../../../utils";
-import {
-  allDevicesDiffTestsForSignedOut,
-  macbook15,
-} from "../../../../utils/devices";
+import { allDevicesDiffTestsForSignedOut } from "../../../../utils/devices";
 import {
   newClickFlow,
   newExpectation,
   newExpectationWithClickFlows,
-  newExpectationWithRedirect,
   newShouldArgs,
   scrollToPosition,
 } from "../../../../utils/helpers";
@@ -15,7 +11,6 @@ import { ClickFlow } from "../../../../utils/types";
 
 const pageName = "Sign in page";
 const currentPage = "/signin";
-const currentPageWithRedirect = "/signin?redirect=%2Fsettings";
 
 describe(`${pageName} renders expected components on different devices`, () => {
   const beVisible = newShouldArgs("be.visible");
@@ -163,21 +158,4 @@ describe(`${pageName} renders expected components on different devices`, () => {
     mobileTests,
   );
   runTestsForDevices({ currentPage, devices });
-
-  // Test that a signin URL with search params redirects to the expected page after signin.
-  const redirectTests = [
-    newExpectationWithRedirect(
-      "should redirect to /settings page after sign in",
-      "[data-cy=settings-header]",
-      beVisible,
-      false,
-      "settings",
-    ),
-  ];
-
-  const devicesForRedirectLink = [macbook15(pageName, redirectTests, false)];
-  runTestsForDevices({
-    currentPage: currentPageWithRedirect,
-    devices: devicesForRedirectLink,
-  });
 });

--- a/cypress/integration/productionTests/publicPaths/render/signin/redirects.spec.ts
+++ b/cypress/integration/productionTests/publicPaths/render/signin/redirects.spec.ts
@@ -17,7 +17,6 @@ describe(`${pageName} renders expected components on different devices`, () => {
       "should redirect to /settings page after sign in",
       "[data-cy=settings-header]",
       beVisible,
-      false,
       "settings",
     ),
   ];

--- a/cypress/integration/productionTests/publicPaths/render/signin/redirects.spec.ts
+++ b/cypress/integration/productionTests/publicPaths/render/signin/redirects.spec.ts
@@ -1,0 +1,30 @@
+import { runTestsForDevices } from "../../../../utils";
+import { macbook15 } from "../../../../utils/devices";
+import {
+  newExpectationWithRedirect,
+  newShouldArgs,
+} from "../../../../utils/helpers";
+
+const pageName = "Sign in page";
+const currentPageWithRedirect = "/signin?redirect=%2Fsettings";
+
+describe(`${pageName} renders expected components on different devices`, () => {
+  const beVisible = newShouldArgs("be.visible");
+
+  // Test that a signin URL with search params redirects to the expected page after signin.
+  const redirectTests = [
+    newExpectationWithRedirect(
+      "should redirect to /settings page after sign in",
+      "[data-cy=settings-header]",
+      beVisible,
+      false,
+      "settings",
+    ),
+  ];
+
+  const devicesForRedirectLink = [macbook15(pageName, redirectTests, false)];
+  runTestsForDevices({
+    currentPage: currentPageWithRedirect,
+    devices: devicesForRedirectLink,
+  });
+});

--- a/cypress/integration/utils/helpers.ts
+++ b/cypress/integration/utils/helpers.ts
@@ -21,6 +21,16 @@ export function newExpectation(
   return { description, selector, shouldArgs, skip };
 }
 
+export function newExpectationWithRedirect(
+  description: string,
+  selector: Selector,
+  shouldArgs: ShouldArgs,
+  skip = false,
+  redirect = "",
+): Expectation {
+  return { description, selector, shouldArgs, skip, redirect };
+}
+
 export function newExpectationWithClickFlows(
   description: string,
   selector: string,

--- a/cypress/integration/utils/helpers.ts
+++ b/cypress/integration/utils/helpers.ts
@@ -21,6 +21,16 @@ export function newExpectation(
   return { description, selector, shouldArgs, skip };
 }
 
+export function newExpectationWithURL(
+  description: string,
+  selector: Selector,
+  shouldArgs: ShouldArgs,
+  skip = false,
+  url = "",
+): Expectation {
+  return { description, selector, shouldArgs, skip, url };
+}
+
 export function newExpectationWithRedirect(
   description: string,
   selector: Selector,

--- a/cypress/integration/utils/helpers.ts
+++ b/cypress/integration/utils/helpers.ts
@@ -25,8 +25,8 @@ export function newExpectationWithURL(
   description: string,
   selector: Selector,
   shouldArgs: ShouldArgs,
+  url: string,
   skip = false,
-  url = "",
 ): Expectation {
   return { description, selector, shouldArgs, skip, url };
 }
@@ -35,8 +35,8 @@ export function newExpectationWithRedirect(
   description: string,
   selector: Selector,
   shouldArgs: ShouldArgs,
+  redirect: string,
   skip = false,
-  redirect = "",
 ): Expectation {
   return { description, selector, shouldArgs, skip, redirect };
 }

--- a/cypress/integration/utils/index.ts
+++ b/cypress/integration/utils/index.ts
@@ -48,8 +48,9 @@ export function runTests({
       it(t.description, () => {
         if (t.redirect) {
           // Sign in and continue to redirect value before starting test assertions
-          testSignInWithRedirect(t.redirect);
+          testLoginAndRedirectBehavior(t.redirect);
         }
+
         testAssertion(t);
 
         if (t.clickFlows) {
@@ -67,8 +68,8 @@ export function runTests({
   });
 }
 
-function testSignInWithRedirect(redirectValue: string) {
-  return cy.completeSignInFromSignInPage(redirectValue);
+function testLoginAndRedirectBehavior(redirectValue: string) {
+  return cy.loginAsCypressTestingFromSigninPageWithRedirect(redirectValue);
 }
 
 type TestsForDevicesArgs = {
@@ -103,7 +104,7 @@ export function runTestsForDevices({
 function testAssertion(t: Expectation) {
   if (Array.isArray(t.selector)) {
     return t.selector.forEach(s =>
-      getAssertionTest(t.description, s, t.shouldArgs, t.typeString),
+      getAssertionTest(t.description, s, t.shouldArgs, t.typeString, t.url),
     );
   }
   return getAssertionTest(
@@ -111,6 +112,7 @@ function testAssertion(t: Expectation) {
     t.selector,
     t.shouldArgs,
     t.typeString,
+    t.url,
   );
 }
 
@@ -119,6 +121,7 @@ function getAssertionTest(
   selectorStr: string,
   shouldArgs: ShouldArgs,
   typeString?: string,
+  url?: string,
 ) {
   const message = `
   Test assertion failed... 
@@ -127,6 +130,11 @@ function getAssertionTest(
 `;
   if (typeString) {
     return cy.get(selectorStr, { timeout: defaultTimeout }).type(typeString);
+  }
+  if (url) {
+    cy.location().then(loc => {
+      return expect(loc.href).to.include(url);
+    });
   }
   if (Array.isArray(shouldArgs.value)) {
     return cy

--- a/cypress/integration/utils/index.ts
+++ b/cypress/integration/utils/index.ts
@@ -48,7 +48,7 @@ export function runTests({
       it(t.description, () => {
         if (t.redirect) {
           // Sign in and continue to redirect value before starting test assertions
-          testLoginAndRedirectBehavior(t.redirect);
+          cy.loginAsCypressTestingFromSigninPageWithRedirect(t.redirect);
         }
 
         testAssertion(t);
@@ -66,10 +66,6 @@ export function runTests({
       });
     }
   });
-}
-
-function testLoginAndRedirectBehavior(redirectValue: string) {
-  return cy.loginAsCypressTestingFromSigninPageWithRedirect(redirectValue);
 }
 
 type TestsForDevicesArgs = {

--- a/cypress/integration/utils/index.ts
+++ b/cypress/integration/utils/index.ts
@@ -49,7 +49,7 @@ export function runTests({
         testAssertion(t);
 
         if (t.redirect) {
-          testSignInRedirect(t.redirect)
+          testSignInRedirect(t.redirect);
         }
 
         if (t.clickFlows) {
@@ -68,7 +68,7 @@ export function runTests({
 }
 
 function testSignInRedirect(redirectValue: string) {
-  return cy.redirectToSignIn(redirectValue)
+  return cy.redirectToSignIn(redirectValue);
 }
 
 type TestsForDevicesArgs = {

--- a/cypress/integration/utils/index.ts
+++ b/cypress/integration/utils/index.ts
@@ -132,7 +132,7 @@ function getAssertionTest(
     return cy.get(selectorStr, { timeout: defaultTimeout }).type(typeString);
   }
   if (url) {
-    cy.location().then(loc => {
+    return cy.location().then(loc => {
       return expect(loc.href).to.include(url);
     });
   }

--- a/cypress/integration/utils/index.ts
+++ b/cypress/integration/utils/index.ts
@@ -46,11 +46,11 @@ export function runTests({
       xit(t.description, () => {});
     } else {
       it(t.description, () => {
-        testAssertion(t);
-
         if (t.redirect) {
-          testSignInRedirect(t.redirect);
+          // Sign in and continue to redirect value before starting test assertions
+          testSignInWithRedirect(t.redirect);
         }
+        testAssertion(t);
 
         if (t.clickFlows) {
           testClickFlows({
@@ -67,8 +67,8 @@ export function runTests({
   });
 }
 
-function testSignInRedirect(redirectValue: string) {
-  return cy.redirectToSignIn(redirectValue);
+function testSignInWithRedirect(redirectValue: string) {
+  return cy.completeSignInFromSignInPage(redirectValue);
 }
 
 type TestsForDevicesArgs = {

--- a/cypress/integration/utils/index.ts
+++ b/cypress/integration/utils/index.ts
@@ -48,6 +48,10 @@ export function runTests({
       it(t.description, () => {
         testAssertion(t);
 
+        if (t.redirect) {
+          testSignInRedirect(t.redirect)
+        }
+
         if (t.clickFlows) {
           testClickFlows({
             clickFlows: t.clickFlows,
@@ -61,6 +65,10 @@ export function runTests({
       });
     }
   });
+}
+
+function testSignInRedirect(redirectValue: string) {
+  return cy.redirectToSignIn(redirectValue)
 }
 
 type TestsForDevicesArgs = {

--- a/cypress/integration/utils/sharedTests/navbar.ts
+++ b/cypress/integration/utils/sharedTests/navbar.ts
@@ -58,7 +58,7 @@ export const testSignedOutNavbar: Tests = [
 
 export const testSignedInNavbar: Tests = [
   newExpectation(
-    "should have signed out navbar and correct links",
+    "should have signed in navbar and correct links",
     signedInNavbarLinks,
     beVisible,
   ),

--- a/cypress/integration/utils/types.ts
+++ b/cypress/integration/utils/types.ts
@@ -31,6 +31,7 @@ export type Expectation = {
   scrollTo?: ScrollTo;
   skip?: boolean;
   typeString?: string;
+  redirect?: string;
 };
 
 export type ClickFlow = {

--- a/cypress/integration/utils/types.ts
+++ b/cypress/integration/utils/types.ts
@@ -32,6 +32,7 @@ export type Expectation = {
   skip?: boolean;
   typeString?: string;
   redirect?: string;
+  url?: string;
 };
 
 export type ClickFlow = {

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -48,7 +48,7 @@ Cypress.Commands.add(
 );
 
 Cypress.Commands.add(
-  "loginAsCypressTestingFromSigninPage",
+  "loginAsCypressTestingFromSigninPageWithRedirect",
   (redirectValue: string) => {
     cy.location("pathname", { timeout: defaultTimeout }).should(
       "eq",
@@ -115,9 +115,10 @@ Cypress.Commands.add("visitPage", (currentPage: string, loggedIn: boolean) => {
     });
   });
 
-  if (loggedIn)
+  if (loggedIn) {
     // If page tests require a user to be logged in, go to signin page and log in test user
     cy.loginAsCypressTestingAfterNavigateToSignin();
+  }
 
   // 404 page should be rendered when page not found
   cy.visit(currentPage, { failOnStatusCode: false });

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -78,6 +78,14 @@ function ensureSuccessfulLogin(redirectValue?: string) {
   cy.get("[data-cy=navbar-menu-avatar]", { timeout: defaultTimeout }).should(
     "be.visible",
   );
+
+  // Due to restrictions on our GraphQL config, cookies are not set in local development.
+  // Set cookie manually on localhost.
+  cy.location().then(loc => {
+    if (loc.hostname === "localhost") {
+      cy.setCookie("dolthubToken", "anything");
+    }
+  });
 }
 
 function completeLoginForCypressTesting() {
@@ -99,6 +107,7 @@ function completeLoginForCypressTesting() {
 Cypress.Commands.add("signout", () => {
   cy.get("[data-cy=navbar-menu-avatar]", { timeout: defaultTimeout }).click();
   cy.get("[data-cy=sign-out-button]", { timeout: defaultTimeout }).click();
+  cy.clearCookie("dolthubToken");
 });
 
 Cypress.Commands.add("visitPage", (currentPage: string, loggedIn: boolean) => {

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -33,16 +33,35 @@ Cypress.Commands.add("dataCy", (value: string) => {
   return cy.get(`[data-cy=${value}]`);
 });
 
-Cypress.Commands.add("loginAsCypressTesting", (redirectValue?: string) => {
-  if (!password || !username) {
-    throw new Error("Username or password env not set");
-  }
+Cypress.Commands.add(
+  "loginAsCypressTestingAfterNavigateToSignin",
+  (redirectValue?: string) => {
+    if (!password || !username) {
+      throw new Error("Username or password env not set");
+    }
 
-  cy.visit("/signin");
-  cy.visitViewport("macbook-15");
-  completeLoginForCypressTesting();
-  ensureSuccessfulLogin(redirectValue);
-});
+    cy.visit("/signin");
+    cy.visitViewport("macbook-15");
+    completeLoginForCypressTesting();
+    ensureSuccessfulLogin(redirectValue);
+  },
+);
+
+Cypress.Commands.add(
+  "loginAsCypressTestingFromSigninPage",
+  (redirectValue: string) => {
+    cy.location("pathname", { timeout: defaultTimeout }).should(
+      "eq",
+      `/signin`,
+    );
+    cy.location("search", { timeout: defaultTimeout })
+      .should("eq", `?redirect=%2F${redirectValue}`)
+      .then(() => {
+        completeLoginForCypressTesting();
+        ensureSuccessfulLogin(redirectValue);
+      });
+  },
+);
 
 function ensureSuccessfulLogin(redirectValue?: string) {
   if (redirectValue) {
@@ -77,23 +96,6 @@ function completeLoginForCypressTesting() {
     .type("{enter}");
 }
 
-// Assumes /signin page and viewport is already loaded
-Cypress.Commands.add(
-  "completeSignInFromSignInPage",
-  (redirectValue: string) => {
-    cy.location("pathname", { timeout: defaultTimeout }).should(
-      "eq",
-      `/signin`,
-    );
-    cy.location("search", { timeout: defaultTimeout }).should(
-      "eq",
-      `?redirect=%2F${redirectValue}`,
-    );
-    completeLoginForCypressTesting();
-    ensureSuccessfulLogin(redirectValue);
-  },
-);
-
 Cypress.Commands.add("signout", () => {
   cy.get("[data-cy=navbar-menu-avatar]", { timeout: defaultTimeout }).click();
   cy.get("[data-cy=sign-out-button]", { timeout: defaultTimeout }).click();
@@ -115,7 +117,7 @@ Cypress.Commands.add("visitPage", (currentPage: string, loggedIn: boolean) => {
 
   if (loggedIn)
     // If page tests require a user to be logged in, go to signin page and log in test user
-    cy.loginAsCypressTesting();
+    cy.loginAsCypressTestingAfterNavigateToSignin();
 
   // 404 page should be rendered when page not found
   cy.visit(currentPage, { failOnStatusCode: false });

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -78,14 +78,6 @@ function ensureSuccessfulLogin(redirectValue?: string) {
   cy.get("[data-cy=navbar-menu-avatar]", { timeout: defaultTimeout }).should(
     "be.visible",
   );
-
-  // Due to restrictions on our GraphQL config, cookies are not set in local development.
-  // Set cookie manually on localhost.
-  cy.location().then(loc => {
-    if (loc.hostname === "localhost") {
-      cy.setCookie("dolthubToken", "anything");
-    }
-  });
 }
 
 function completeLoginForCypressTesting() {

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -66,6 +66,17 @@ Cypress.Commands.add("loginAsCypressTesting", () => {
   );
 });
 
+Cypress.Commands.add("redirectToSignIn", (redirectValue: string)=>{
+  cy.location("pathname", { timeout: defaultTimeout }).should(
+    "eq",
+    `/signin`,
+  )
+  cy.location("search", { timeout: defaultTimeout }).should(
+    "eq",
+    `?redirect=%2F${redirectValue}`,
+  )
+})
+
 Cypress.Commands.add("signout", () => {
   cy.get("[data-cy=navbar-menu-avatar]", { timeout: defaultTimeout }).click();
   cy.get("[data-cy=sign-out-button]", { timeout: defaultTimeout }).click();
@@ -97,3 +108,4 @@ Cypress.Commands.add("visitViewport", (device: Cypress.ViewportPreset) => {
   // eslint-disable-next-line cypress/no-unnecessary-waiting
   cy.wait(200);
 });
+

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -66,16 +66,13 @@ Cypress.Commands.add("loginAsCypressTesting", () => {
   );
 });
 
-Cypress.Commands.add("redirectToSignIn", (redirectValue: string)=>{
-  cy.location("pathname", { timeout: defaultTimeout }).should(
-    "eq",
-    `/signin`,
-  )
+Cypress.Commands.add("redirectToSignIn", (redirectValue: string) => {
+  cy.location("pathname", { timeout: defaultTimeout }).should("eq", `/signin`);
   cy.location("search", { timeout: defaultTimeout }).should(
     "eq",
     `?redirect=%2F${redirectValue}`,
-  )
-})
+  );
+});
 
 Cypress.Commands.add("signout", () => {
   cy.get("[data-cy=navbar-menu-avatar]", { timeout: defaultTimeout }).click();
@@ -108,4 +105,3 @@ Cypress.Commands.add("visitViewport", (device: Cypress.ViewportPreset) => {
   // eslint-disable-next-line cypress/no-unnecessary-waiting
   cy.wait(200);
 });
-

--- a/cypress/support/global.d.ts
+++ b/cypress/support/global.d.ts
@@ -14,6 +14,8 @@ declare namespace Cypress {
 
     signout(): void;
 
+    redirectToSignIn(redirectValue: string): void;
+
     visitPage(currentPage: string, loggedIn: boolean): void;
 
     visitViewport(device: Cypress.ViewportPreset): void;

--- a/cypress/support/global.d.ts
+++ b/cypress/support/global.d.ts
@@ -10,11 +10,11 @@ declare namespace Cypress {
      */
     dataCy(value: string): Chainable<Element>;
 
-    loginAsCypressTesting(): void;
+    loginAsCypressTesting(redirectValue?: string): void;
 
     signout(): void;
 
-    redirectToSignIn(redirectValue: string): void;
+    completeSignInFromSignInPage(redirectValue: string): void;
 
     visitPage(currentPage: string, loggedIn: boolean): void;
 

--- a/cypress/support/global.d.ts
+++ b/cypress/support/global.d.ts
@@ -10,11 +10,13 @@ declare namespace Cypress {
      */
     dataCy(value: string): Chainable<Element>;
 
-    loginAsCypressTesting(redirectValue?: string): void;
+    loginAsCypressTestingAfterNavigateToSignin(redirectValue?: string): void;
 
     signout(): void;
 
-    completeSignInFromSignInPage(redirectValue: string): void;
+    loginAsCypressTestingFromSigninPageWithRedirect(
+      redirectValue: string,
+    ): void;
 
     visitPage(currentPage: string, loggedIn: boolean): void;
 

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "cy-run": "cypress run",
     "cy-chrome": "cypress run --browser chrome --headless",
     "cy-open-dev": "CYPRESS_BASE_URL=https://dolthub.awsdev.ld-corp.com cypress open",
+    "cy-run-dev": "CYPRESS_BASE_URL=https://dolthub.awsdev.ld-corp.com cypress run",
     "cylo-open-dolthub": "export CYPRESS_LOCAL_DOLTHUB=true && CYPRESS_BASE_URL=http://localhost:3000 cypress open",
     "cylo-open-blog": "export CYPRESS_LOCAL_BLOG=true && CYPRESS_BASE_URL=http://localhost:8000 cypress open",
     "cylo-open-docs": "export CYPRESS_LOCAL_DOCS=true && CYPRESS_BASE_URL=http://localhost:8000 cypress open",


### PR DESCRIPTION
This PR adds test coverage for: 

- [X] logged **out** users who visit `/settings` are routed to the sign in page, and redirect info is preserved in URL `/signin?redirect=%2Fsettings`.
- [X] logged **out** user who visits`/signin?redirect=%2Fsettings` is routed to `/settings` _after a successful login_
- [X] logged **IN** user who visits `/settings` is properly routed to the Settings page
- [X] `/settings/development` renders 404 on dev/prod, and renders Development page content on localhost 

I added 2 fields to the `type Expectation`:

```
  redirect?: string;
  url?: string;
```

* **redirect**: Expected pathname after we're signed in. 
For example, if the currentPage is `/signin?redirect=%2Fsettings`, then `redirect = "settings"`.
The test will check that the url contains `settings` after successfully logging in.
Because of this order, test assertions are done _after_ completing the redirect (to the settings page in this case).
Note: Right now this test is really only used for `signin` redirects, and maybe needs a better name? Like... `redirectValueForSuccessfulLogin`? 🥴

* **url**: Expected URL
For example, if the currentPage is `/settings` for a logged out user, they will automatically be redirected to `/signin?redirect=%2Fsettings`. In this case, you want to test that the URL we were directed to, matches our expected URL.
So you would supply the expected `url = "/signin?redirect=%2Fsettings`.


Other improvements:
- [X] On localhost only, manually set/clear `dolthubToken` cookie after successful login, and after signing out. 
     - Fixed logged in navbar tests that were previously failing locally