### PR TITLE
Only run desktop/tablet tests for team page

### DIFF
--- a/cypress/integration/productionTests/publicPaths/render/team/index.spec.ts
+++ b/cypress/integration/productionTests/publicPaths/render/team/index.spec.ts
@@ -1,5 +1,5 @@
 import { runTestsForDevices } from "../../../../utils";
-import { allDevicesForSignedOut } from "../../../../utils/devices";
+import { allDevicesDiffTestsForSignedOut } from "../../../../utils/devices";
 import { newExpectation, newShouldArgs } from "../../../../utils/helpers";
 
 const pageName = "Team page";
@@ -24,6 +24,6 @@ describe(`${pageName} renders expected components on different devices`, () => {
     ),
   ];
 
-  const devices = allDevicesForSignedOut(pageName, tests, tests);
+  const devices = allDevicesDiffTestsForSignedOut(pageName, tests, tests, []);
   runTestsForDevices({ currentPage, devices });
 });


### PR DESCRIPTION
The Team anchor test was occasionally failing on iphone x, so now I'm just running desktop and tablet tests. It appears to be working correctly in production. The failure is from a cypress scroll issue that I couldn't immediately figure out.

<img width="1285" alt="Screen Shot 2021-06-22 at 11 50 02 AM" src="https://user-images.githubusercontent.com/13577488/122982670-fdde1800-d34f-11eb-904e-8671bc0b1c8c.png">