### PR TITLE
Kathleen database tests for left nav functionality

### DIFF
--- a/cypress/integration/productionTests/privatePaths/render/database/empty.spec.ts
+++ b/cypress/integration/productionTests/privatePaths/render/database/empty.spec.ts
@@ -1,7 +1,7 @@
 import {
   testTablesSection,
   testViewsSection,
-  testQueryCatalogSection
+  testQueryCatalogSection,
 } from "cypress/integration/utils/sharedTests/repoDatabaseNav";
 import { runTestsForDevices } from "../../../../utils";
 import { macbook15ForAppLayout } from "../../../../utils/devices";
@@ -62,7 +62,7 @@ describe(`${pageName} renders expected components on different devices`, () => {
     ...testDoltInstallationSteps,
     ...testTablesSection(hasDocs, hasBranch, loggedIn, 0),
     testViewsSection(hasBranch, 0),
-    testQueryCatalogSection(hasBranch, 0)
+    testQueryCatalogSection(hasBranch, 0),
   ];
   const skip = false;
   const devices = [macbook15ForAppLayout(pageName, tests, false, loggedIn)];

--- a/cypress/integration/productionTests/privatePaths/render/database/empty.spec.ts
+++ b/cypress/integration/productionTests/privatePaths/render/database/empty.spec.ts
@@ -1,3 +1,7 @@
+import {
+  testTablesSection,
+  testViewsSection,
+} from "cypress/integration/utils/sharedTests/repoDatabaseNav";
 import { runTestsForDevices } from "../../../../utils";
 import { macbook15ForAppLayout } from "../../../../utils/devices";
 import {
@@ -14,6 +18,7 @@ const currentRepo = "empty_repo";
 const currentPage = `repositories/${currentOwner}/${currentRepo}`;
 const loggedIn = true;
 const hasDocs = false;
+const hasBranch = false;
 
 describe(`${pageName} renders expected components on different devices`, () => {
   const beVisible = newShouldArgs("be.visible");
@@ -54,6 +59,8 @@ describe(`${pageName} renders expected components on different devices`, () => {
       true,
     ),
     ...testDoltInstallationSteps,
+    ...testTablesSection(hasDocs, hasBranch, loggedIn, 0),
+    testViewsSection(hasBranch, 0),
   ];
   const skip = false;
   const devices = [macbook15ForAppLayout(pageName, tests, false, loggedIn)];

--- a/cypress/integration/productionTests/privatePaths/render/database/empty.spec.ts
+++ b/cypress/integration/productionTests/privatePaths/render/database/empty.spec.ts
@@ -2,6 +2,7 @@ import {
   testTablesSection,
   testViewsSection,
   testQueryCatalogSection,
+  testSchemaSection
 } from "cypress/integration/utils/sharedTests/repoDatabaseNav";
 import { runTestsForDevices } from "../../../../utils";
 import { macbook15ForAppLayout } from "../../../../utils/devices";
@@ -63,6 +64,7 @@ describe(`${pageName} renders expected components on different devices`, () => {
     ...testTablesSection(hasDocs, hasBranch, loggedIn, 0),
     testViewsSection(hasBranch, 0),
     testQueryCatalogSection(hasBranch, 0),
+    testSchemaSection(hasBranch, 0),
   ];
   const skip = false;
   const devices = [macbook15ForAppLayout(pageName, tests, false, loggedIn)];

--- a/cypress/integration/productionTests/privatePaths/render/database/empty.spec.ts
+++ b/cypress/integration/productionTests/privatePaths/render/database/empty.spec.ts
@@ -4,6 +4,7 @@ import {
   testQueryCatalogSection,
   testSchemaSection,
 } from "cypress/integration/utils/sharedTests/repoDatabaseNav";
+import { testSqlConsole } from "cypress/integration/utils/sharedTests/sqlEditor";
 import { runTestsForDevices } from "../../../../utils";
 import { macbook15ForAppLayout } from "../../../../utils/devices";
 import {
@@ -26,7 +27,6 @@ describe(`${pageName} renders expected components on different devices`, () => {
   const beVisible = newShouldArgs("be.visible");
   const notExist = newShouldArgs("not.exist");
 
-  // TODO: Add tests for left side database navigation
   const tests = [
     ...testRepoHeaderForAll(currentRepo, currentOwner, loggedIn, hasDocs),
     newExpectation(
@@ -65,6 +65,7 @@ describe(`${pageName} renders expected components on different devices`, () => {
     testViewsSection(hasBranch, 0),
     testQueryCatalogSection(hasBranch, 0),
     testSchemaSection(hasBranch, 0),
+    testSqlConsole,
   ];
   const skip = false;
   const devices = [macbook15ForAppLayout(pageName, tests, false, loggedIn)];

--- a/cypress/integration/productionTests/privatePaths/render/database/empty.spec.ts
+++ b/cypress/integration/productionTests/privatePaths/render/database/empty.spec.ts
@@ -1,6 +1,7 @@
 import {
   testTablesSection,
   testViewsSection,
+  testQueryCatalogSection
 } from "cypress/integration/utils/sharedTests/repoDatabaseNav";
 import { runTestsForDevices } from "../../../../utils";
 import { macbook15ForAppLayout } from "../../../../utils/devices";
@@ -61,6 +62,7 @@ describe(`${pageName} renders expected components on different devices`, () => {
     ...testDoltInstallationSteps,
     ...testTablesSection(hasDocs, hasBranch, loggedIn, 0),
     testViewsSection(hasBranch, 0),
+    testQueryCatalogSection(hasBranch, 0)
   ];
   const skip = false;
   const devices = [macbook15ForAppLayout(pageName, tests, false, loggedIn)];

--- a/cypress/integration/productionTests/privatePaths/render/database/empty.spec.ts
+++ b/cypress/integration/productionTests/privatePaths/render/database/empty.spec.ts
@@ -2,7 +2,7 @@ import {
   testTablesSection,
   testViewsSection,
   testQueryCatalogSection,
-  testSchemaSection
+  testSchemaSection,
 } from "cypress/integration/utils/sharedTests/repoDatabaseNav";
 import { runTestsForDevices } from "../../../../utils";
 import { macbook15ForAppLayout } from "../../../../utils/devices";

--- a/cypress/integration/productionTests/privatePaths/render/database/empty.spec.ts
+++ b/cypress/integration/productionTests/privatePaths/render/database/empty.spec.ts
@@ -3,8 +3,8 @@ import {
   testViewsSection,
   testQueryCatalogSection,
   testSchemaSection,
-} from "cypress/integration/utils/sharedTests/repoDatabaseNav";
-import { testSqlConsole } from "cypress/integration/utils/sharedTests/sqlEditor";
+} from "../../../../utils/sharedTests/repoDatabaseNav";
+import { testSqlConsole } from "../../../../utils/sharedTests/sqlEditor";
 import { runTestsForDevices } from "../../../../utils";
 import { macbook15ForAppLayout } from "../../../../utils/devices";
 import {

--- a/cypress/integration/productionTests/privatePaths/render/database/emptyWithBranch.spec.ts
+++ b/cypress/integration/productionTests/privatePaths/render/database/emptyWithBranch.spec.ts
@@ -1,3 +1,4 @@
+import { testSqlConsole } from "cypress/integration/utils/sharedTests/sqlEditor";
 import { runTestsForDevices } from "../../../../utils";
 import { macbook15ForAppLayout } from "../../../../utils/devices";
 import {
@@ -64,6 +65,7 @@ describe(`${pageName} renders expected components on different devices`, () => {
     testViewsSection(hasBranch, 0),
     testQueryCatalogSection(hasBranch, 0),
     testSchemaSection(hasBranch, 0),
+    testSqlConsole,
   ];
   const skip = false;
   const devices = [macbook15ForAppLayout(pageName, tests, false, loggedIn)];

--- a/cypress/integration/productionTests/privatePaths/render/database/emptyWithBranch.spec.ts
+++ b/cypress/integration/productionTests/privatePaths/render/database/emptyWithBranch.spec.ts
@@ -9,6 +9,7 @@ import { testDoltInstallationSteps } from "../../../../utils/sharedTests/emptyRe
 import {
   testTablesSection,
   testViewsSection,
+  testQueryCatalogSection
 } from "../../../../utils/sharedTests/repoDatabaseNav";
 import { testRepoHeaderWithBranch } from "../../../../utils/sharedTests/repoHeaderNav";
 
@@ -60,6 +61,7 @@ describe(`${pageName} renders expected components on different devices`, () => {
     ...testDoltInstallationSteps,
     ...testTablesSection(hasDocs, hasBranch, loggedIn, 0),
     testViewsSection(hasBranch, 0),
+    testQueryCatalogSection(hasBranch, 0)
   ];
   const skip = false;
   const devices = [macbook15ForAppLayout(pageName, tests, false, loggedIn)];

--- a/cypress/integration/productionTests/privatePaths/render/database/emptyWithBranch.spec.ts
+++ b/cypress/integration/productionTests/privatePaths/render/database/emptyWithBranch.spec.ts
@@ -9,7 +9,7 @@ import { testDoltInstallationSteps } from "../../../../utils/sharedTests/emptyRe
 import {
   testTablesSection,
   testViewsSection,
-  testQueryCatalogSection
+  testQueryCatalogSection,
 } from "../../../../utils/sharedTests/repoDatabaseNav";
 import { testRepoHeaderWithBranch } from "../../../../utils/sharedTests/repoHeaderNav";
 
@@ -61,7 +61,7 @@ describe(`${pageName} renders expected components on different devices`, () => {
     ...testDoltInstallationSteps,
     ...testTablesSection(hasDocs, hasBranch, loggedIn, 0),
     testViewsSection(hasBranch, 0),
-    testQueryCatalogSection(hasBranch, 0)
+    testQueryCatalogSection(hasBranch, 0),
   ];
   const skip = false;
   const devices = [macbook15ForAppLayout(pageName, tests, false, loggedIn)];

--- a/cypress/integration/productionTests/privatePaths/render/database/emptyWithBranch.spec.ts
+++ b/cypress/integration/productionTests/privatePaths/render/database/emptyWithBranch.spec.ts
@@ -15,13 +15,14 @@ const currentRepo = "empty_repo_with_branch";
 const currentPage = `repositories/${currentOwner}/${currentRepo}`;
 const loggedIn = true;
 const hasDocs = false;
+const hasBranch = true;
 
 describe(`${pageName} renders expected components on different devices`, () => {
   const beVisible = newShouldArgs("be.visible");
 
   const tests = [
     ...testRepoHeaderWithBranch(currentRepo, currentOwner, loggedIn, hasDocs),
-    ...testTablesSection(0),
+    ...testTablesSection(hasBranch, 0),
     newExpectation(
       "should have database Get Started section",
       "[data-cy=repo-empty-get-started]",

--- a/cypress/integration/productionTests/privatePaths/render/database/emptyWithBranch.spec.ts
+++ b/cypress/integration/productionTests/privatePaths/render/database/emptyWithBranch.spec.ts
@@ -10,6 +10,7 @@ import {
   testTablesSection,
   testViewsSection,
   testQueryCatalogSection,
+  testSchemaSection,
 } from "../../../../utils/sharedTests/repoDatabaseNav";
 import { testRepoHeaderWithBranch } from "../../../../utils/sharedTests/repoHeaderNav";
 
@@ -62,6 +63,7 @@ describe(`${pageName} renders expected components on different devices`, () => {
     ...testTablesSection(hasDocs, hasBranch, loggedIn, 0),
     testViewsSection(hasBranch, 0),
     testQueryCatalogSection(hasBranch, 0),
+    testSchemaSection(hasBranch, 0),
   ];
   const skip = false;
   const devices = [macbook15ForAppLayout(pageName, tests, false, loggedIn)];

--- a/cypress/integration/productionTests/privatePaths/render/database/emptyWithBranch.spec.ts
+++ b/cypress/integration/productionTests/privatePaths/render/database/emptyWithBranch.spec.ts
@@ -22,7 +22,7 @@ describe(`${pageName} renders expected components on different devices`, () => {
 
   const tests = [
     ...testRepoHeaderWithBranch(currentRepo, currentOwner, loggedIn, hasDocs),
-    ...testTablesSection(hasBranch, 0),
+    ...testTablesSection(hasBranch, loggedIn, 0),
     newExpectation(
       "should have database Get Started section",
       "[data-cy=repo-empty-get-started]",

--- a/cypress/integration/productionTests/privatePaths/render/database/emptyWithBranch.spec.ts
+++ b/cypress/integration/productionTests/privatePaths/render/database/emptyWithBranch.spec.ts
@@ -6,7 +6,10 @@ import {
   newShouldArgs,
 } from "../../../../utils/helpers";
 import { testDoltInstallationSteps } from "../../../../utils/sharedTests/emptyRepo";
-import { testTablesSection } from "../../../../utils/sharedTests/repoDatabaseNav";
+import {
+  testTablesSection,
+  testViewsSection,
+} from "../../../../utils/sharedTests/repoDatabaseNav";
 import { testRepoHeaderWithBranch } from "../../../../utils/sharedTests/repoHeaderNav";
 
 const pageName = "Logged in database page with branch and no data";
@@ -22,7 +25,6 @@ describe(`${pageName} renders expected components on different devices`, () => {
 
   const tests = [
     ...testRepoHeaderWithBranch(currentRepo, currentOwner, loggedIn, hasDocs),
-    ...testTablesSection(hasBranch, loggedIn, 0),
     newExpectation(
       "should have database Get Started section",
       "[data-cy=repo-empty-get-started]",
@@ -56,6 +58,8 @@ describe(`${pageName} renders expected components on different devices`, () => {
       true,
     ),
     ...testDoltInstallationSteps,
+    ...testTablesSection(hasDocs, hasBranch, loggedIn, 0),
+    testViewsSection(hasBranch, 0),
   ];
   const skip = false;
   const devices = [macbook15ForAppLayout(pageName, tests, false, loggedIn)];

--- a/cypress/integration/productionTests/privatePaths/render/database/emptyWithBranch.spec.ts
+++ b/cypress/integration/productionTests/privatePaths/render/database/emptyWithBranch.spec.ts
@@ -1,4 +1,4 @@
-import { testSqlConsole } from "cypress/integration/utils/sharedTests/sqlEditor";
+import { testSqlConsole } from "../../../../utils/sharedTests/sqlEditor";
 import { runTestsForDevices } from "../../../../utils";
 import { macbook15ForAppLayout } from "../../../../utils/devices";
 import {

--- a/cypress/integration/productionTests/privatePaths/render/database/tablesAndDocs.spec.ts
+++ b/cypress/integration/productionTests/privatePaths/render/database/tablesAndDocs.spec.ts
@@ -41,7 +41,8 @@ describe(`${pageName} renders expected components on different devices`, () => {
     //   beVisible,
     // ),
     // testSqlConsole,
-    ...testRepoHeaderWithBranch(currentRepo, currentOwner, loggedIn, false),
+    ...testRepoHeaderWithBranch(currentRepo, currentOwner, loggedIn, false),  
+    // Why can you still add a readme when it already has one? I think this is the only page that does that. Make sure to fix this logic later.
     // testAboutSection(true),
     ...tableExpectations(hasDocs, hasBranch, loggedIn, 1, "test_table"),
     // testIndexesSection(1, "test_table"),

--- a/cypress/integration/productionTests/privatePaths/render/database/tablesAndDocs.spec.ts
+++ b/cypress/integration/productionTests/privatePaths/render/database/tablesAndDocs.spec.ts
@@ -1,4 +1,7 @@
-import { tableExpectations } from "cypress/integration/utils/sharedTests/repoDatabaseNav";
+import {
+  tableExpectations,
+  testViewsSection,
+} from "cypress/integration/utils/sharedTests/repoDatabaseNav";
 import { runTestsForDevices } from "../../../../utils";
 import { macbook15ForAppLayout } from "../../../../utils/devices";
 import { newExpectation, newShouldArgs } from "../../../../utils/helpers";
@@ -9,7 +12,7 @@ const currentOwner = "automated_testing";
 const currentRepo = "repo_tables_and_docs";
 const currentPage = `repositories/${currentOwner}/${currentRepo}`;
 const loggedIn = true;
-const hasDocs = false;
+const hasDocs = true;
 const hasBranch = true;
 
 describe(`${pageName} renders expected components on different devices`, () => {
@@ -38,11 +41,11 @@ describe(`${pageName} renders expected components on different devices`, () => {
     //   beVisible,
     // ),
     // testSqlConsole,
-    ...testRepoHeaderWithBranch(currentRepo, currentOwner, loggedIn, hasDocs),
+    ...testRepoHeaderWithBranch(currentRepo, currentOwner, loggedIn, false),
     // testAboutSection(true),
-    ...tableExpectations(hasBranch, loggedIn, 1, "test_table"),
+    ...tableExpectations(hasDocs, hasBranch, loggedIn, 1, "test_table"),
     // testIndexesSection(1, "test_table"),
-    // testViewsSection(0),
+    testViewsSection(hasBranch, 0),
     // testQueryCatalogSection(0),
     // testCommitSection(4),
     // testReleasesSection(0),

--- a/cypress/integration/productionTests/privatePaths/render/database/tablesAndDocs.spec.ts
+++ b/cypress/integration/productionTests/privatePaths/render/database/tablesAndDocs.spec.ts
@@ -2,6 +2,7 @@ import {
   tableExpectations,
   testViewsSection,
   testQueryCatalogSection,
+  testSchemaSection,
 } from "cypress/integration/utils/sharedTests/repoDatabaseNav";
 import { runTestsForDevices } from "../../../../utils";
 import { macbook15ForAppLayout } from "../../../../utils/devices";
@@ -40,6 +41,7 @@ describe(`${pageName} renders expected components on different devices`, () => {
     ...tableExpectations(hasDocs, hasBranch, loggedIn, 1, "test_table"),
     testViewsSection(hasBranch, 0),
     testQueryCatalogSection(hasBranch, 0),
+    testSchemaSection(hasBranch, 1, "test_table"),
 
     // newExpectation(
     //   "should have upload file button",

--- a/cypress/integration/productionTests/privatePaths/render/database/tablesAndDocs.spec.ts
+++ b/cypress/integration/productionTests/privatePaths/render/database/tablesAndDocs.spec.ts
@@ -1,7 +1,7 @@
 import {
   tableExpectations,
   testViewsSection,
-  testQueryCatalogSection
+  testQueryCatalogSection,
 } from "cypress/integration/utils/sharedTests/repoDatabaseNav";
 import { runTestsForDevices } from "../../../../utils";
 import { macbook15ForAppLayout } from "../../../../utils/devices";
@@ -36,11 +36,10 @@ describe(`${pageName} renders expected components on different devices`, () => {
       "[data-cy=repo-doc-markdown]",
       beVisible,
     ),
-    ...testRepoHeaderWithBranch(currentRepo, currentOwner, loggedIn, false),  
+    ...testRepoHeaderWithBranch(currentRepo, currentOwner, loggedIn, false),
     ...tableExpectations(hasDocs, hasBranch, loggedIn, 1, "test_table"),
     testViewsSection(hasBranch, 0),
     testQueryCatalogSection(hasBranch, 0),
-
 
     // newExpectation(
     //   "should have upload file button",

--- a/cypress/integration/productionTests/privatePaths/render/database/tablesAndDocs.spec.ts
+++ b/cypress/integration/productionTests/privatePaths/render/database/tablesAndDocs.spec.ts
@@ -1,6 +1,7 @@
 import {
   tableExpectations,
   testViewsSection,
+  testQueryCatalogSection
 } from "cypress/integration/utils/sharedTests/repoDatabaseNav";
 import { runTestsForDevices } from "../../../../utils";
 import { macbook15ForAppLayout } from "../../../../utils/devices";
@@ -35,19 +36,21 @@ describe(`${pageName} renders expected components on different devices`, () => {
       "[data-cy=repo-doc-markdown]",
       beVisible,
     ),
+    ...testRepoHeaderWithBranch(currentRepo, currentOwner, loggedIn, false),  
+    ...tableExpectations(hasDocs, hasBranch, loggedIn, 1, "test_table"),
+    testViewsSection(hasBranch, 0),
+    testQueryCatalogSection(hasBranch, 0),
+
+
     // newExpectation(
     //   "should have upload file button",
     //   "[data-cy=upload-file-button]",
     //   beVisible,
     // ),
     // testSqlConsole,
-    ...testRepoHeaderWithBranch(currentRepo, currentOwner, loggedIn, false),  
     // Why can you still add a readme when it already has one? I think this is the only page that does that. Make sure to fix this logic later.
     // testAboutSection(true),
-    ...tableExpectations(hasDocs, hasBranch, loggedIn, 1, "test_table"),
     // testIndexesSection(1, "test_table"),
-    testViewsSection(hasBranch, 0),
-    // testQueryCatalogSection(0),
     // testCommitSection(4),
     // testReleasesSection(0),
     // testPullRequestsSection(0),

--- a/cypress/integration/productionTests/privatePaths/render/database/tablesAndDocs.spec.ts
+++ b/cypress/integration/productionTests/privatePaths/render/database/tablesAndDocs.spec.ts
@@ -3,8 +3,8 @@ import {
   testViewsSection,
   testQueryCatalogSection,
   testSchemaSection,
-} from "cypress/integration/utils/sharedTests/repoDatabaseNav";
-import { testSqlConsole } from "cypress/integration/utils/sharedTests/sqlEditor";
+} from "../../../../utils/sharedTests/repoDatabaseNav";
+import { testSqlConsole } from "../../../../utils/sharedTests/sqlEditor";
 import { runTestsForDevices } from "../../../../utils";
 import { macbook15ForAppLayout } from "../../../../utils/devices";
 import { newExpectation, newShouldArgs } from "../../../../utils/helpers";

--- a/cypress/integration/productionTests/privatePaths/render/database/tablesAndDocs.spec.ts
+++ b/cypress/integration/productionTests/privatePaths/render/database/tablesAndDocs.spec.ts
@@ -4,6 +4,7 @@ import {
   testQueryCatalogSection,
   testSchemaSection,
 } from "cypress/integration/utils/sharedTests/repoDatabaseNav";
+import { testSqlConsole } from "cypress/integration/utils/sharedTests/sqlEditor";
 import { runTestsForDevices } from "../../../../utils";
 import { macbook15ForAppLayout } from "../../../../utils/devices";
 import { newExpectation, newShouldArgs } from "../../../../utils/helpers";
@@ -42,14 +43,12 @@ describe(`${pageName} renders expected components on different devices`, () => {
     testViewsSection(hasBranch, 0),
     testQueryCatalogSection(hasBranch, 0),
     testSchemaSection(hasBranch, 1, "test_table"),
-
-    // newExpectation(
-    //   "should have upload file button",
-    //   "[data-cy=upload-file-button]",
-    //   beVisible,
-    // ),
-    // testSqlConsole,
-    // Why can you still add a readme when it already has one? I think this is the only page that does that. Make sure to fix this logic later.
+    newExpectation(
+      "should have upload file button",
+      "[data-cy=upload-file-button]",
+      beVisible,
+    ),
+    testSqlConsole,
     // testAboutSection(true),
     // testIndexesSection(1, "test_table"),
     // testCommitSection(4),

--- a/cypress/integration/productionTests/privatePaths/render/database/tablesAndDocs.spec.ts
+++ b/cypress/integration/productionTests/privatePaths/render/database/tablesAndDocs.spec.ts
@@ -1,4 +1,4 @@
-import { testTablesSection } from "cypress/integration/utils/sharedTests/repoDatabaseNav";
+import { tableExpectations } from "cypress/integration/utils/sharedTests/repoDatabaseNav";
 import { runTestsForDevices } from "../../../../utils";
 import { macbook15ForAppLayout } from "../../../../utils/devices";
 import { newExpectation, newShouldArgs } from "../../../../utils/helpers";
@@ -39,7 +39,7 @@ describe(`${pageName} renders expected components on different devices`, () => {
     // testSqlConsole,
     ...testRepoHeaderWithBranch(currentRepo, currentOwner, loggedIn, hasDocs),
     // testAboutSection(true),
-    ...testTablesSection(1, "test_table"),
+    ...tableExpectations(1, "test_table"),
     // testIndexesSection(1, "test_table"),
     // testViewsSection(0),
     // testQueryCatalogSection(0),

--- a/cypress/integration/productionTests/privatePaths/render/database/tablesAndDocs.spec.ts
+++ b/cypress/integration/productionTests/privatePaths/render/database/tablesAndDocs.spec.ts
@@ -43,12 +43,12 @@ describe(`${pageName} renders expected components on different devices`, () => {
     testViewsSection(hasBranch, 0),
     testQueryCatalogSection(hasBranch, 0),
     testSchemaSection(hasBranch, 1, "test_table"),
-    newExpectation(
-      "should have upload file button",
-      "[data-cy=upload-file-button]",
-      beVisible,
-    ),
     testSqlConsole,
+    // newExpectation(
+    //   "should have upload file button",
+    //   "[data-cy=upload-file-button]",
+    //   beVisible,
+    // ),
     // testAboutSection(true),
     // testIndexesSection(1, "test_table"),
     // testCommitSection(4),

--- a/cypress/integration/productionTests/privatePaths/render/database/tablesAndDocs.spec.ts
+++ b/cypress/integration/productionTests/privatePaths/render/database/tablesAndDocs.spec.ts
@@ -1,3 +1,4 @@
+import { testTablesSection } from "cypress/integration/utils/sharedTests/repoDatabaseNav";
 import { runTestsForDevices } from "../../../../utils";
 import { macbook15ForAppLayout } from "../../../../utils/devices";
 import { newExpectation, newShouldArgs } from "../../../../utils/helpers";
@@ -38,7 +39,7 @@ describe(`${pageName} renders expected components on different devices`, () => {
     // testSqlConsole,
     ...testRepoHeaderWithBranch(currentRepo, currentOwner, loggedIn, hasDocs),
     // testAboutSection(true),
-    // testTablesSection(1, "test_table"),
+    ...testTablesSection(1, "test_table"),
     // testIndexesSection(1, "test_table"),
     // testViewsSection(0),
     // testQueryCatalogSection(0),

--- a/cypress/integration/productionTests/privatePaths/render/database/tablesAndDocs.spec.ts
+++ b/cypress/integration/productionTests/privatePaths/render/database/tablesAndDocs.spec.ts
@@ -44,18 +44,6 @@ describe(`${pageName} renders expected components on different devices`, () => {
     testQueryCatalogSection(hasBranch, 0),
     testSchemaSection(hasBranch, 1, "test_table"),
     testSqlConsole,
-    // newExpectation(
-    //   "should have upload file button",
-    //   "[data-cy=upload-file-button]",
-    //   beVisible,
-    // ),
-    // testAboutSection(true),
-    // testIndexesSection(1, "test_table"),
-    // testCommitSection(4),
-    // testReleasesSection(0),
-    // testPullRequestsSection(0),
-    // testCollaboratorsSection(1),
-    // testRepoSettings,
   ];
 
   const devices = [macbook15ForAppLayout(pageName, tests, false, loggedIn)];

--- a/cypress/integration/productionTests/privatePaths/render/database/tablesAndDocs.spec.ts
+++ b/cypress/integration/productionTests/privatePaths/render/database/tablesAndDocs.spec.ts
@@ -10,6 +10,7 @@ const currentRepo = "repo_tables_and_docs";
 const currentPage = `repositories/${currentOwner}/${currentRepo}`;
 const loggedIn = true;
 const hasDocs = false;
+const hasBranch = true;
 
 describe(`${pageName} renders expected components on different devices`, () => {
   const beVisible = newShouldArgs("be.visible");
@@ -39,7 +40,7 @@ describe(`${pageName} renders expected components on different devices`, () => {
     // testSqlConsole,
     ...testRepoHeaderWithBranch(currentRepo, currentOwner, loggedIn, hasDocs),
     // testAboutSection(true),
-    ...tableExpectations(1, "test_table"),
+    ...tableExpectations(hasBranch, 1, "test_table"),
     // testIndexesSection(1, "test_table"),
     // testViewsSection(0),
     // testQueryCatalogSection(0),

--- a/cypress/integration/productionTests/privatePaths/render/database/tablesAndDocs.spec.ts
+++ b/cypress/integration/productionTests/privatePaths/render/database/tablesAndDocs.spec.ts
@@ -40,7 +40,7 @@ describe(`${pageName} renders expected components on different devices`, () => {
     // testSqlConsole,
     ...testRepoHeaderWithBranch(currentRepo, currentOwner, loggedIn, hasDocs),
     // testAboutSection(true),
-    ...tableExpectations(hasBranch, 1, "test_table"),
+    ...tableExpectations(hasBranch, loggedIn, 1, "test_table"),
     // testIndexesSection(1, "test_table"),
     // testViewsSection(0),
     // testQueryCatalogSection(0),

--- a/cypress/integration/productionTests/publicPaths/render/database/corona-virus.spec.ts
+++ b/cypress/integration/productionTests/publicPaths/render/database/corona-virus.spec.ts
@@ -4,6 +4,7 @@ import { newExpectation, newShouldArgs } from "../../../../utils/helpers";
 import {
   tableExpectations,
   testViewsSection,
+  testQueryCatalogSection
 } from "../../../../utils/sharedTests/repoDatabaseNav";
 import { testRepoHeaderWithBranch } from "../../../../utils/sharedTests/repoHeaderNav";
 
@@ -16,7 +17,7 @@ const hasDocs = true;
 const hasBranch = true;
 
 const testView = "cases_by_age_range";
-// const testQuery = "mortality_rates";
+const testQuery = "mortality_rates";
 
 // TODO: Write tests for commented out sections for left nav
 describe(`${pageName} renders expected components on different devices`, () => {
@@ -42,10 +43,10 @@ describe(`${pageName} renders expected components on different devices`, () => {
     ...testRepoHeaderWithBranch(currentRepo, currentOwner, loggedIn, hasDocs),
     ...tableExpectations(hasDocs, hasBranch, loggedIn, 11, "case_details"),
     testViewsSection(hasBranch, 15, testView),
+    testQueryCatalogSection(hasBranch, 10, testQuery),
     // testAboutSection(true),
     // ...testPaginationForRepoDataTable,
     // testSchemasSection(11, "case_details"),
-    // testQueryCatalogSection(10, testQuery),
   ];
 
   const devices = [macbook15ForAppLayout(pageName, tests)];

--- a/cypress/integration/productionTests/publicPaths/render/database/corona-virus.spec.ts
+++ b/cypress/integration/productionTests/publicPaths/render/database/corona-virus.spec.ts
@@ -38,7 +38,7 @@ describe(`${pageName} renders expected components on different devices`, () => {
     ),
     ...testRepoHeaderWithBranch(currentRepo, currentOwner, loggedIn, hasDocs),
     // testAboutSection(true),
-    ...tableExpectations(hasBranch, 11, "case_details"),
+    ...tableExpectations(hasBranch, loggedIn, 11, "case_details"),
     // ...testPaginationForRepoDataTable,
     // testSchemasSection(11, "case_details"),
     // testViewsSection(15, testView),

--- a/cypress/integration/productionTests/publicPaths/render/database/corona-virus.spec.ts
+++ b/cypress/integration/productionTests/publicPaths/render/database/corona-virus.spec.ts
@@ -1,3 +1,4 @@
+import { testSqlConsole } from "cypress/integration/utils/sharedTests/sqlEditor";
 import { runTestsForDevices } from "../../../../utils";
 import { macbook15ForAppLayout } from "../../../../utils/devices";
 import { newExpectation, newShouldArgs } from "../../../../utils/helpers";
@@ -5,6 +6,7 @@ import {
   tableExpectations,
   testViewsSection,
   testQueryCatalogSection,
+  testSchemaSection,
 } from "../../../../utils/sharedTests/repoDatabaseNav";
 import { testRepoHeaderWithBranch } from "../../../../utils/sharedTests/repoHeaderNav";
 
@@ -44,9 +46,10 @@ describe(`${pageName} renders expected components on different devices`, () => {
     ...tableExpectations(hasDocs, hasBranch, loggedIn, 11, "case_details"),
     testViewsSection(hasBranch, 15, testView),
     testQueryCatalogSection(hasBranch, 10, testQuery),
+    testSchemaSection(hasBranch, 11, "case_details"),
+    testSqlConsole,
     // testAboutSection(true),
     // ...testPaginationForRepoDataTable,
-    // testSchemasSection(11, "case_details"),
   ];
 
   const devices = [macbook15ForAppLayout(pageName, tests)];

--- a/cypress/integration/productionTests/publicPaths/render/database/corona-virus.spec.ts
+++ b/cypress/integration/productionTests/publicPaths/render/database/corona-virus.spec.ts
@@ -1,7 +1,10 @@
 import { runTestsForDevices } from "../../../../utils";
 import { macbook15ForAppLayout } from "../../../../utils/devices";
 import { newExpectation, newShouldArgs } from "../../../../utils/helpers";
-import { tableExpectations } from "../../../../utils/sharedTests/repoDatabaseNav";
+import {
+  tableExpectations,
+  testViewsSection,
+} from "../../../../utils/sharedTests/repoDatabaseNav";
 import { testRepoHeaderWithBranch } from "../../../../utils/sharedTests/repoHeaderNav";
 
 const pageName = "Database page (corona-virus) with tables and docs";
@@ -12,7 +15,7 @@ const loggedIn = false;
 const hasDocs = true;
 const hasBranch = true;
 
-// const testView = "cases_by_age_range";
+const testView = "cases_by_age_range";
 // const testQuery = "mortality_rates";
 
 // TODO: Write tests for commented out sections for left nav
@@ -37,11 +40,11 @@ describe(`${pageName} renders expected components on different devices`, () => {
       beVisible,
     ),
     ...testRepoHeaderWithBranch(currentRepo, currentOwner, loggedIn, hasDocs),
+    ...tableExpectations(hasDocs, hasBranch, loggedIn, 11, "case_details"),
+    testViewsSection(hasBranch, 15, testView),
     // testAboutSection(true),
-    ...tableExpectations(hasBranch, loggedIn, 11, "case_details"),
     // ...testPaginationForRepoDataTable,
     // testSchemasSection(11, "case_details"),
-    // testViewsSection(15, testView),
     // testQueryCatalogSection(10, testQuery),
   ];
 

--- a/cypress/integration/productionTests/publicPaths/render/database/corona-virus.spec.ts
+++ b/cypress/integration/productionTests/publicPaths/render/database/corona-virus.spec.ts
@@ -1,4 +1,4 @@
-import { testSqlConsole } from "cypress/integration/utils/sharedTests/sqlEditor";
+import { testSqlConsole } from "../../../../utils/sharedTests/sqlEditor";
 import { runTestsForDevices } from "../../../../utils";
 import { macbook15ForAppLayout } from "../../../../utils/devices";
 import { newExpectation, newShouldArgs } from "../../../../utils/helpers";

--- a/cypress/integration/productionTests/publicPaths/render/database/corona-virus.spec.ts
+++ b/cypress/integration/productionTests/publicPaths/render/database/corona-virus.spec.ts
@@ -10,6 +10,7 @@ const currentRepo = "corona-virus";
 const currentPage = `repositories/${currentOwner}/${currentRepo}`;
 const loggedIn = false;
 const hasDocs = true;
+const hasBranch = true;
 
 // const testView = "cases_by_age_range";
 // const testQuery = "mortality_rates";
@@ -37,7 +38,7 @@ describe(`${pageName} renders expected components on different devices`, () => {
     ),
     ...testRepoHeaderWithBranch(currentRepo, currentOwner, loggedIn, hasDocs),
     // testAboutSection(true),
-    ...tableExpectations(11, "case_details"),
+    ...tableExpectations(hasBranch, 11, "case_details"),
     // ...testPaginationForRepoDataTable,
     // testSchemasSection(11, "case_details"),
     // testViewsSection(15, testView),

--- a/cypress/integration/productionTests/publicPaths/render/database/corona-virus.spec.ts
+++ b/cypress/integration/productionTests/publicPaths/render/database/corona-virus.spec.ts
@@ -48,8 +48,6 @@ describe(`${pageName} renders expected components on different devices`, () => {
     testQueryCatalogSection(hasBranch, 10, testQuery),
     testSchemaSection(hasBranch, 11, "case_details"),
     testSqlConsole,
-    // testAboutSection(true),
-    // ...testPaginationForRepoDataTable,
   ];
 
   const devices = [macbook15ForAppLayout(pageName, tests)];

--- a/cypress/integration/productionTests/publicPaths/render/database/corona-virus.spec.ts
+++ b/cypress/integration/productionTests/publicPaths/render/database/corona-virus.spec.ts
@@ -21,7 +21,6 @@ const hasBranch = true;
 const testView = "cases_by_age_range";
 const testQuery = "mortality_rates";
 
-// TODO: Write tests for commented out sections for left nav
 describe(`${pageName} renders expected components on different devices`, () => {
   const beVisible = newShouldArgs("be.visible");
   const notExist = newShouldArgs("not.exist");

--- a/cypress/integration/productionTests/publicPaths/render/database/corona-virus.spec.ts
+++ b/cypress/integration/productionTests/publicPaths/render/database/corona-virus.spec.ts
@@ -4,7 +4,7 @@ import { newExpectation, newShouldArgs } from "../../../../utils/helpers";
 import {
   tableExpectations,
   testViewsSection,
-  testQueryCatalogSection
+  testQueryCatalogSection,
 } from "../../../../utils/sharedTests/repoDatabaseNav";
 import { testRepoHeaderWithBranch } from "../../../../utils/sharedTests/repoHeaderNav";
 

--- a/cypress/integration/productionTests/publicPaths/render/database/docsNoTables.spec.ts
+++ b/cypress/integration/productionTests/publicPaths/render/database/docsNoTables.spec.ts
@@ -17,7 +17,6 @@ const loggedIn = false;
 const hasDocs = true;
 const hasBranch = true;
 
-// TODO: Test commented out sections for left nav
 describe(`${pageName} renders expected components on different devices`, () => {
   const beVisible = newShouldArgs("be.visible");
   const notExist = newShouldArgs("not.exist");

--- a/cypress/integration/productionTests/publicPaths/render/database/docsNoTables.spec.ts
+++ b/cypress/integration/productionTests/publicPaths/render/database/docsNoTables.spec.ts
@@ -43,7 +43,6 @@ describe(`${pageName} renders expected components on different devices`, () => {
     testViewsSection(hasBranch, 0),
     testQueryCatalogSection(hasBranch, 0),
     testSchemaSection(hasBranch, 0),
-    // testAboutSection(true),
   ];
 
   const devices = [macbook15ForAppLayout(pageName, tests)];

--- a/cypress/integration/productionTests/publicPaths/render/database/docsNoTables.spec.ts
+++ b/cypress/integration/productionTests/publicPaths/render/database/docsNoTables.spec.ts
@@ -4,6 +4,7 @@ import { newExpectation, newShouldArgs } from "../../../../utils/helpers";
 import {
   tableExpectations,
   testViewsSection,
+  testQueryCatalogSection
 } from "../../../../utils/sharedTests/repoDatabaseNav";
 import { testRepoHeaderWithBranch } from "../../../../utils/sharedTests/repoHeaderNav";
 
@@ -41,7 +42,7 @@ describe(`${pageName} renders expected components on different devices`, () => {
     testViewsSection(hasBranch, 0),
     // testAboutSection(true),
     // testSchemasSection(0),
-    // testQueryCatalogSection(0),
+    testQueryCatalogSection(hasBranch, 0),
   ];
 
   const devices = [macbook15ForAppLayout(pageName, tests)];

--- a/cypress/integration/productionTests/publicPaths/render/database/docsNoTables.spec.ts
+++ b/cypress/integration/productionTests/publicPaths/render/database/docsNoTables.spec.ts
@@ -5,6 +5,7 @@ import {
   tableExpectations,
   testViewsSection,
   testQueryCatalogSection,
+  testSchemaSection,
 } from "../../../../utils/sharedTests/repoDatabaseNav";
 import { testRepoHeaderWithBranch } from "../../../../utils/sharedTests/repoHeaderNav";
 
@@ -40,9 +41,9 @@ describe(`${pageName} renders expected components on different devices`, () => {
     ...testRepoHeaderWithBranch(currentRepo, currentOwner, loggedIn, hasDocs),
     ...tableExpectations(hasDocs, hasBranch, loggedIn, 0),
     testViewsSection(hasBranch, 0),
-    // testAboutSection(true),
-    // testSchemasSection(0),
     testQueryCatalogSection(hasBranch, 0),
+    testSchemaSection(hasBranch, 0),
+    // testAboutSection(true),
   ];
 
   const devices = [macbook15ForAppLayout(pageName, tests)];

--- a/cypress/integration/productionTests/publicPaths/render/database/docsNoTables.spec.ts
+++ b/cypress/integration/productionTests/publicPaths/render/database/docsNoTables.spec.ts
@@ -35,7 +35,7 @@ describe(`${pageName} renders expected components on different devices`, () => {
     ),
     ...testRepoHeaderWithBranch(currentRepo, currentOwner, loggedIn, hasDocs),
     // testAboutSection(true),
-    ...tableExpectations(hasBranch, 0),
+    ...tableExpectations(hasBranch, loggedIn, 0),
     // testSchemasSection(0),
     // testViewsSection(0),
     // testQueryCatalogSection(0),

--- a/cypress/integration/productionTests/publicPaths/render/database/docsNoTables.spec.ts
+++ b/cypress/integration/productionTests/publicPaths/render/database/docsNoTables.spec.ts
@@ -10,6 +10,7 @@ const currentRepo = "repo_docs_no_tables";
 const currentPage = `repositories/${currentOwner}/${currentRepo}`;
 const loggedIn = false;
 const hasDocs = true;
+const hasBranch = true;
 
 // TODO: Test commented out sections for left nav
 describe(`${pageName} renders expected components on different devices`, () => {
@@ -34,7 +35,7 @@ describe(`${pageName} renders expected components on different devices`, () => {
     ),
     ...testRepoHeaderWithBranch(currentRepo, currentOwner, loggedIn, hasDocs),
     // testAboutSection(true),
-    ...tableExpectations(0),
+    ...tableExpectations(hasBranch, 0),
     // testSchemasSection(0),
     // testViewsSection(0),
     // testQueryCatalogSection(0),

--- a/cypress/integration/productionTests/publicPaths/render/database/docsNoTables.spec.ts
+++ b/cypress/integration/productionTests/publicPaths/render/database/docsNoTables.spec.ts
@@ -1,7 +1,10 @@
 import { runTestsForDevices } from "../../../../utils";
 import { macbook15ForAppLayout } from "../../../../utils/devices";
 import { newExpectation, newShouldArgs } from "../../../../utils/helpers";
-import { tableExpectations } from "../../../../utils/sharedTests/repoDatabaseNav";
+import {
+  tableExpectations,
+  testViewsSection,
+} from "../../../../utils/sharedTests/repoDatabaseNav";
 import { testRepoHeaderWithBranch } from "../../../../utils/sharedTests/repoHeaderNav";
 
 const pageName = "Database page with docs and no tables";
@@ -34,10 +37,10 @@ describe(`${pageName} renders expected components on different devices`, () => {
       beVisible,
     ),
     ...testRepoHeaderWithBranch(currentRepo, currentOwner, loggedIn, hasDocs),
+    ...tableExpectations(hasDocs, hasBranch, loggedIn, 0),
+    testViewsSection(hasBranch, 0),
     // testAboutSection(true),
-    ...tableExpectations(hasBranch, loggedIn, 0),
     // testSchemasSection(0),
-    // testViewsSection(0),
     // testQueryCatalogSection(0),
   ];
 

--- a/cypress/integration/productionTests/publicPaths/render/database/docsNoTables.spec.ts
+++ b/cypress/integration/productionTests/publicPaths/render/database/docsNoTables.spec.ts
@@ -4,7 +4,7 @@ import { newExpectation, newShouldArgs } from "../../../../utils/helpers";
 import {
   tableExpectations,
   testViewsSection,
-  testQueryCatalogSection
+  testQueryCatalogSection,
 } from "../../../../utils/sharedTests/repoDatabaseNav";
 import { testRepoHeaderWithBranch } from "../../../../utils/sharedTests/repoHeaderNav";
 

--- a/cypress/integration/productionTests/publicPaths/render/database/empty.spec.ts
+++ b/cypress/integration/productionTests/publicPaths/render/database/empty.spec.ts
@@ -63,7 +63,7 @@ describe(`${pageName} renders expected components on different devices`, () => {
     ),
     ...testDoltInstallationSteps,
     testSqlConsole,
-    ...testTablesSection(hasBranch, 0),
+    ...testTablesSection(hasBranch, loggedIn, 0),
   ];
 
   const devices = [macbook15ForAppLayout(pageName, tests)];

--- a/cypress/integration/productionTests/publicPaths/render/database/empty.spec.ts
+++ b/cypress/integration/productionTests/publicPaths/render/database/empty.spec.ts
@@ -16,6 +16,7 @@ const currentRepo = "empty_repo";
 const currentPage = `repositories/${currentOwner}/${currentRepo}`;
 const loggedIn = false;
 const hasDocs = false;
+const hasBranch = false;
 
 describe(`${pageName} renders expected components on different devices`, () => {
   const beVisible = newShouldArgs("be.visible");
@@ -62,7 +63,7 @@ describe(`${pageName} renders expected components on different devices`, () => {
     ),
     ...testDoltInstallationSteps,
     testSqlConsole,
-    ...testTablesSection(0),
+    ...testTablesSection(hasBranch, 0),
   ];
 
   const devices = [macbook15ForAppLayout(pageName, tests)];

--- a/cypress/integration/productionTests/publicPaths/render/database/empty.spec.ts
+++ b/cypress/integration/productionTests/publicPaths/render/database/empty.spec.ts
@@ -9,6 +9,7 @@ import { testDoltInstallationSteps } from "../../../../utils/sharedTests/emptyRe
 import {
   testTablesSection,
   testViewsSection,
+  testQueryCatalogSection
 } from "../../../../utils/sharedTests/repoDatabaseNav";
 import { testRepoHeaderForAll } from "../../../../utils/sharedTests/repoHeaderNav";
 // import { testSqlConsole } from "../../../../utils/sharedTests/sqlEditor";
@@ -67,6 +68,7 @@ describe(`${pageName} renders expected components on different devices`, () => {
     ...testDoltInstallationSteps,
     ...testTablesSection(hasDocs, hasBranch, loggedIn, 0),
     testViewsSection(hasBranch, 0),
+    testQueryCatalogSection(hasBranch, 0)
     // testSqlConsole,
   ];
 

--- a/cypress/integration/productionTests/publicPaths/render/database/empty.spec.ts
+++ b/cypress/integration/productionTests/publicPaths/render/database/empty.spec.ts
@@ -1,3 +1,4 @@
+import { testSqlConsole } from "cypress/integration/utils/sharedTests/sqlEditor";
 import { runTestsForDevices } from "../../../../utils";
 import { macbook15ForAppLayout } from "../../../../utils/devices";
 import {
@@ -10,6 +11,7 @@ import {
   testTablesSection,
   testViewsSection,
   testQueryCatalogSection,
+  testSchemaSection,
 } from "../../../../utils/sharedTests/repoDatabaseNav";
 import { testRepoHeaderForAll } from "../../../../utils/sharedTests/repoHeaderNav";
 // import { testSqlConsole } from "../../../../utils/sharedTests/sqlEditor";
@@ -69,7 +71,8 @@ describe(`${pageName} renders expected components on different devices`, () => {
     ...testTablesSection(hasDocs, hasBranch, loggedIn, 0),
     testViewsSection(hasBranch, 0),
     testQueryCatalogSection(hasBranch, 0),
-    // testSqlConsole,
+    testSchemaSection(hasBranch, 0),
+    testSqlConsole,
   ];
 
   const devices = [macbook15ForAppLayout(pageName, tests)];

--- a/cypress/integration/productionTests/publicPaths/render/database/empty.spec.ts
+++ b/cypress/integration/productionTests/publicPaths/render/database/empty.spec.ts
@@ -14,7 +14,6 @@ import {
   testSchemaSection,
 } from "../../../../utils/sharedTests/repoDatabaseNav";
 import { testRepoHeaderForAll } from "../../../../utils/sharedTests/repoHeaderNav";
-// import { testSqlConsole } from "../../../../utils/sharedTests/sqlEditor";
 
 const pageName = "Database page with no branch and no data";
 const currentOwner = "automated_testing";

--- a/cypress/integration/productionTests/publicPaths/render/database/empty.spec.ts
+++ b/cypress/integration/productionTests/publicPaths/render/database/empty.spec.ts
@@ -9,7 +9,7 @@ import { testDoltInstallationSteps } from "../../../../utils/sharedTests/emptyRe
 import {
   testTablesSection,
   testViewsSection,
-  testQueryCatalogSection
+  testQueryCatalogSection,
 } from "../../../../utils/sharedTests/repoDatabaseNav";
 import { testRepoHeaderForAll } from "../../../../utils/sharedTests/repoHeaderNav";
 // import { testSqlConsole } from "../../../../utils/sharedTests/sqlEditor";
@@ -68,7 +68,7 @@ describe(`${pageName} renders expected components on different devices`, () => {
     ...testDoltInstallationSteps,
     ...testTablesSection(hasDocs, hasBranch, loggedIn, 0),
     testViewsSection(hasBranch, 0),
-    testQueryCatalogSection(hasBranch, 0)
+    testQueryCatalogSection(hasBranch, 0),
     // testSqlConsole,
   ];
 

--- a/cypress/integration/productionTests/publicPaths/render/database/empty.spec.ts
+++ b/cypress/integration/productionTests/publicPaths/render/database/empty.spec.ts
@@ -1,4 +1,4 @@
-import { testSqlConsole } from "cypress/integration/utils/sharedTests/sqlEditor";
+import { testSqlConsole } from "../../../../utils/sharedTests/sqlEditor";
 import { runTestsForDevices } from "../../../../utils";
 import { macbook15ForAppLayout } from "../../../../utils/devices";
 import {

--- a/cypress/integration/productionTests/publicPaths/render/database/empty.spec.ts
+++ b/cypress/integration/productionTests/publicPaths/render/database/empty.spec.ts
@@ -27,7 +27,6 @@ describe(`${pageName} renders expected components on different devices`, () => {
   const beVisible = newShouldArgs("be.visible");
   const notExist = newShouldArgs("not.exist");
 
-  // TODO: Add tests for left side database navigation
   const tests = [
     ...testRepoHeaderForAll(currentRepo, currentOwner, loggedIn, hasDocs),
     newExpectation(

--- a/cypress/integration/productionTests/publicPaths/render/database/empty.spec.ts
+++ b/cypress/integration/productionTests/publicPaths/render/database/empty.spec.ts
@@ -6,9 +6,12 @@ import {
   newShouldArgs,
 } from "../../../../utils/helpers";
 import { testDoltInstallationSteps } from "../../../../utils/sharedTests/emptyRepo";
-import { testTablesSection } from "../../../../utils/sharedTests/repoDatabaseNav";
+import {
+  testTablesSection,
+  testViewsSection,
+} from "../../../../utils/sharedTests/repoDatabaseNav";
 import { testRepoHeaderForAll } from "../../../../utils/sharedTests/repoHeaderNav";
-import { testSqlConsole } from "../../../../utils/sharedTests/sqlEditor";
+// import { testSqlConsole } from "../../../../utils/sharedTests/sqlEditor";
 
 const pageName = "Database page with no branch and no data";
 const currentOwner = "automated_testing";
@@ -62,8 +65,9 @@ describe(`${pageName} renders expected components on different devices`, () => {
       true,
     ),
     ...testDoltInstallationSteps,
-    testSqlConsole,
-    ...testTablesSection(hasBranch, loggedIn, 0),
+    ...testTablesSection(hasDocs, hasBranch, loggedIn, 0),
+    testViewsSection(hasBranch, 0),
+    // testSqlConsole,
   ];
 
   const devices = [macbook15ForAppLayout(pageName, tests)];

--- a/cypress/integration/productionTests/publicPaths/render/database/emptyWithBranch.spec.ts
+++ b/cypress/integration/productionTests/publicPaths/render/database/emptyWithBranch.spec.ts
@@ -56,7 +56,7 @@ describe(`${pageName} renders expected components on different devices`, () => {
       true,
     ),
     ...testDoltInstallationSteps,
-    ...testTablesSection(hasBranch, 0),
+    ...testTablesSection(hasBranch, loggedIn, 0),
     testSqlConsole,
   ];
 

--- a/cypress/integration/productionTests/publicPaths/render/database/emptyWithBranch.spec.ts
+++ b/cypress/integration/productionTests/publicPaths/render/database/emptyWithBranch.spec.ts
@@ -16,6 +16,7 @@ const currentRepo = "empty_repo_with_branch";
 const currentPage = `repositories/${currentOwner}/${currentRepo}`;
 const loggedIn = false;
 const hasDocs = false;
+const hasBranch = true;
 
 describe(`${pageName} renders expected components on different devices`, () => {
   const beVisible = newShouldArgs("be.visible");
@@ -55,7 +56,7 @@ describe(`${pageName} renders expected components on different devices`, () => {
       true,
     ),
     ...testDoltInstallationSteps,
-    ...testTablesSection(0),
+    ...testTablesSection(hasBranch, 0),
     testSqlConsole,
   ];
 

--- a/cypress/integration/productionTests/publicPaths/render/database/emptyWithBranch.spec.ts
+++ b/cypress/integration/productionTests/publicPaths/render/database/emptyWithBranch.spec.ts
@@ -9,6 +9,7 @@ import { testDoltInstallationSteps } from "../../../../utils/sharedTests/emptyRe
 import {
   testTablesSection,
   testViewsSection,
+  testQueryCatalogSection
 } from "../../../../utils/sharedTests/repoDatabaseNav";
 import { testRepoHeaderWithBranch } from "../../../../utils/sharedTests/repoHeaderNav";
 // import { testSqlConsole } from "../../../../utils/sharedTests/sqlEditor";
@@ -61,6 +62,7 @@ describe(`${pageName} renders expected components on different devices`, () => {
     ...testDoltInstallationSteps,
     ...testTablesSection(hasDocs, hasBranch, loggedIn, 0),
     testViewsSection(hasBranch, 0),
+    testQueryCatalogSection(hasBranch, 0)
     // testSqlConsole,
   ];
 

--- a/cypress/integration/productionTests/publicPaths/render/database/emptyWithBranch.spec.ts
+++ b/cypress/integration/productionTests/publicPaths/render/database/emptyWithBranch.spec.ts
@@ -9,7 +9,7 @@ import { testDoltInstallationSteps } from "../../../../utils/sharedTests/emptyRe
 import {
   testTablesSection,
   testViewsSection,
-  testQueryCatalogSection
+  testQueryCatalogSection,
 } from "../../../../utils/sharedTests/repoDatabaseNav";
 import { testRepoHeaderWithBranch } from "../../../../utils/sharedTests/repoHeaderNav";
 // import { testSqlConsole } from "../../../../utils/sharedTests/sqlEditor";
@@ -62,7 +62,7 @@ describe(`${pageName} renders expected components on different devices`, () => {
     ...testDoltInstallationSteps,
     ...testTablesSection(hasDocs, hasBranch, loggedIn, 0),
     testViewsSection(hasBranch, 0),
-    testQueryCatalogSection(hasBranch, 0)
+    testQueryCatalogSection(hasBranch, 0),
     // testSqlConsole,
   ];
 

--- a/cypress/integration/productionTests/publicPaths/render/database/emptyWithBranch.spec.ts
+++ b/cypress/integration/productionTests/publicPaths/render/database/emptyWithBranch.spec.ts
@@ -1,3 +1,4 @@
+import { testSqlConsole } from "cypress/integration/utils/sharedTests/sqlEditor";
 import { runTestsForDevices } from "../../../../utils";
 import { macbook15ForAppLayout } from "../../../../utils/devices";
 import {
@@ -10,6 +11,7 @@ import {
   testTablesSection,
   testViewsSection,
   testQueryCatalogSection,
+  testSchemaSection,
 } from "../../../../utils/sharedTests/repoDatabaseNav";
 import { testRepoHeaderWithBranch } from "../../../../utils/sharedTests/repoHeaderNav";
 // import { testSqlConsole } from "../../../../utils/sharedTests/sqlEditor";
@@ -63,7 +65,8 @@ describe(`${pageName} renders expected components on different devices`, () => {
     ...testTablesSection(hasDocs, hasBranch, loggedIn, 0),
     testViewsSection(hasBranch, 0),
     testQueryCatalogSection(hasBranch, 0),
-    // testSqlConsole,
+    testSchemaSection(hasBranch, 0),
+    testSqlConsole,
   ];
 
   const devices = [macbook15ForAppLayout(pageName, tests)];

--- a/cypress/integration/productionTests/publicPaths/render/database/emptyWithBranch.spec.ts
+++ b/cypress/integration/productionTests/publicPaths/render/database/emptyWithBranch.spec.ts
@@ -6,9 +6,12 @@ import {
   newShouldArgs,
 } from "../../../../utils/helpers";
 import { testDoltInstallationSteps } from "../../../../utils/sharedTests/emptyRepo";
-import { testTablesSection } from "../../../../utils/sharedTests/repoDatabaseNav";
+import {
+  testTablesSection,
+  testViewsSection,
+} from "../../../../utils/sharedTests/repoDatabaseNav";
 import { testRepoHeaderWithBranch } from "../../../../utils/sharedTests/repoHeaderNav";
-import { testSqlConsole } from "../../../../utils/sharedTests/sqlEditor";
+// import { testSqlConsole } from "../../../../utils/sharedTests/sqlEditor";
 
 const pageName = "Database page with branch and no data";
 const currentOwner = "automated_testing";
@@ -56,8 +59,9 @@ describe(`${pageName} renders expected components on different devices`, () => {
       true,
     ),
     ...testDoltInstallationSteps,
-    ...testTablesSection(hasBranch, loggedIn, 0),
-    testSqlConsole,
+    ...testTablesSection(hasDocs, hasBranch, loggedIn, 0),
+    testViewsSection(hasBranch, 0),
+    // testSqlConsole,
   ];
 
   const devices = [macbook15ForAppLayout(pageName, tests)];

--- a/cypress/integration/productionTests/publicPaths/render/database/emptyWithBranch.spec.ts
+++ b/cypress/integration/productionTests/publicPaths/render/database/emptyWithBranch.spec.ts
@@ -1,4 +1,4 @@
-import { testSqlConsole } from "cypress/integration/utils/sharedTests/sqlEditor";
+import { testSqlConsole } from "../../../../utils/sharedTests/sqlEditor";
 import { runTestsForDevices } from "../../../../utils";
 import { macbook15ForAppLayout } from "../../../../utils/devices";
 import {

--- a/cypress/integration/productionTests/publicPaths/render/database/forked.spec.ts
+++ b/cypress/integration/productionTests/publicPaths/render/database/forked.spec.ts
@@ -55,8 +55,6 @@ describe(`${pageName} renders expected components on different devices`, () => {
     testQueryCatalogSection(hasBranch, 0),
     testSchemaSection(hasBranch, 2, "IPv4ToCountry"),
     testSqlConsole,
-    // testAboutSection(false),
-    // ...testPaginationForRepoDataTable,
   ];
 
   const devices = [macbook15ForAppLayout(pageName, tests)];

--- a/cypress/integration/productionTests/publicPaths/render/database/forked.spec.ts
+++ b/cypress/integration/productionTests/publicPaths/render/database/forked.spec.ts
@@ -50,7 +50,7 @@ describe(`${pageName} renders expected components on different devices`, () => {
       "[data-cy=forked-parent-repo-detail]",
       beVisible,
     ),
-    ...tableExpectations(hasDocs, hasBranch, loggedIn, 2, "IPv6ToCountry"),
+    ...tableExpectations(hasDocs, hasBranch, loggedIn, 2, "IPv4ToCountry"),
     testViewsSection(hasBranch, 0),
     testQueryCatalogSection(hasBranch, 0),
     // testAboutSection(false),

--- a/cypress/integration/productionTests/publicPaths/render/database/forked.spec.ts
+++ b/cypress/integration/productionTests/publicPaths/render/database/forked.spec.ts
@@ -4,7 +4,7 @@ import { newExpectation, newShouldArgs } from "../../../../utils/helpers";
 import {
   tableExpectations,
   testViewsSection,
-  testQueryCatalogSection
+  testQueryCatalogSection,
 } from "../../../../utils/sharedTests/repoDatabaseNav";
 import { testRepoHeaderWithBranch } from "../../../../utils/sharedTests/repoHeaderNav";
 import { testSqlConsole } from "../../../../utils/sharedTests/sqlEditor";

--- a/cypress/integration/productionTests/publicPaths/render/database/forked.spec.ts
+++ b/cypress/integration/productionTests/publicPaths/render/database/forked.spec.ts
@@ -47,7 +47,7 @@ describe(`${pageName} renders expected components on different devices`, () => {
       beVisible,
     ),
     // testAboutSection(false),
-    ...tableExpectations(hasBranch, 2, "IPv6ToCountry"),
+    ...tableExpectations(hasBranch, loggedIn, 2, "IPv6ToCountry"),
     // ...testPaginationForRepoDataTable,
     // testSchemasSection(2, "IPv4ToCountry"),
     // testViewsSection(0),

--- a/cypress/integration/productionTests/publicPaths/render/database/forked.spec.ts
+++ b/cypress/integration/productionTests/publicPaths/render/database/forked.spec.ts
@@ -11,6 +11,7 @@ const currentRepo = "ip-to-country";
 const currentPage = `repositories/${currentOwner}/${currentRepo}`;
 const loggedIn = false;
 const hasDocs = false;
+const hasBranch = true;
 
 // TODO: Test commented out sections for left nav
 describe(`${pageName} renders expected components on different devices`, () => {
@@ -46,7 +47,7 @@ describe(`${pageName} renders expected components on different devices`, () => {
       beVisible,
     ),
     // testAboutSection(false),
-    ...tableExpectations(2, "IPv6ToCountry"),
+    ...tableExpectations(hasBranch, 2, "IPv6ToCountry"),
     // ...testPaginationForRepoDataTable,
     // testSchemasSection(2, "IPv4ToCountry"),
     // testViewsSection(0),

--- a/cypress/integration/productionTests/publicPaths/render/database/forked.spec.ts
+++ b/cypress/integration/productionTests/publicPaths/render/database/forked.spec.ts
@@ -18,7 +18,6 @@ const loggedIn = false;
 const hasDocs = false;
 const hasBranch = true;
 
-// TODO: Test commented out sections for left nav
 describe(`${pageName} renders expected components on different devices`, () => {
   const beVisible = newShouldArgs("be.visible");
   const notExist = newShouldArgs("not.exist");

--- a/cypress/integration/productionTests/publicPaths/render/database/forked.spec.ts
+++ b/cypress/integration/productionTests/publicPaths/render/database/forked.spec.ts
@@ -1,7 +1,10 @@
 import { runTestsForDevices } from "../../../../utils";
 import { macbook15ForAppLayout } from "../../../../utils/devices";
 import { newExpectation, newShouldArgs } from "../../../../utils/helpers";
-import { tableExpectations } from "../../../../utils/sharedTests/repoDatabaseNav";
+import {
+  tableExpectations,
+  testViewsSection,
+} from "../../../../utils/sharedTests/repoDatabaseNav";
 import { testRepoHeaderWithBranch } from "../../../../utils/sharedTests/repoHeaderNav";
 import { testSqlConsole } from "../../../../utils/sharedTests/sqlEditor";
 
@@ -46,11 +49,11 @@ describe(`${pageName} renders expected components on different devices`, () => {
       "[data-cy=forked-parent-repo-detail]",
       beVisible,
     ),
+    ...tableExpectations(hasDocs, hasBranch, loggedIn, 2, "IPv6ToCountry"),
+    testViewsSection(hasBranch, 0),
     // testAboutSection(false),
-    ...tableExpectations(hasBranch, loggedIn, 2, "IPv6ToCountry"),
     // ...testPaginationForRepoDataTable,
     // testSchemasSection(2, "IPv4ToCountry"),
-    // testViewsSection(0),
     // testQueryCatalogSection(0),
   ];
 

--- a/cypress/integration/productionTests/publicPaths/render/database/forked.spec.ts
+++ b/cypress/integration/productionTests/publicPaths/render/database/forked.spec.ts
@@ -4,6 +4,7 @@ import { newExpectation, newShouldArgs } from "../../../../utils/helpers";
 import {
   tableExpectations,
   testViewsSection,
+  testQueryCatalogSection
 } from "../../../../utils/sharedTests/repoDatabaseNav";
 import { testRepoHeaderWithBranch } from "../../../../utils/sharedTests/repoHeaderNav";
 import { testSqlConsole } from "../../../../utils/sharedTests/sqlEditor";
@@ -51,10 +52,10 @@ describe(`${pageName} renders expected components on different devices`, () => {
     ),
     ...tableExpectations(hasDocs, hasBranch, loggedIn, 2, "IPv6ToCountry"),
     testViewsSection(hasBranch, 0),
+    testQueryCatalogSection(hasBranch, 0),
     // testAboutSection(false),
     // ...testPaginationForRepoDataTable,
     // testSchemasSection(2, "IPv4ToCountry"),
-    // testQueryCatalogSection(0),
   ];
 
   const devices = [macbook15ForAppLayout(pageName, tests)];

--- a/cypress/integration/productionTests/publicPaths/render/database/forked.spec.ts
+++ b/cypress/integration/productionTests/publicPaths/render/database/forked.spec.ts
@@ -5,6 +5,7 @@ import {
   tableExpectations,
   testViewsSection,
   testQueryCatalogSection,
+  testSchemaSection,
 } from "../../../../utils/sharedTests/repoDatabaseNav";
 import { testRepoHeaderWithBranch } from "../../../../utils/sharedTests/repoHeaderNav";
 import { testSqlConsole } from "../../../../utils/sharedTests/sqlEditor";
@@ -43,7 +44,6 @@ describe(`${pageName} renders expected components on different devices`, () => {
       "[data-cy=repo-data-table-columns] > th",
       newShouldArgs("be.visible.and.have.length", 8),
     ),
-    testSqlConsole,
     ...testRepoHeaderWithBranch(currentRepo, currentOwner, loggedIn, hasDocs),
     newExpectation(
       "should find forked repo parent detail",
@@ -53,9 +53,10 @@ describe(`${pageName} renders expected components on different devices`, () => {
     ...tableExpectations(hasDocs, hasBranch, loggedIn, 2, "IPv4ToCountry"),
     testViewsSection(hasBranch, 0),
     testQueryCatalogSection(hasBranch, 0),
+    testSchemaSection(hasBranch, 2, "IPv4ToCountry"),
+    testSqlConsole,
     // testAboutSection(false),
     // ...testPaginationForRepoDataTable,
-    // testSchemasSection(2, "IPv4ToCountry"),
   ];
 
   const devices = [macbook15ForAppLayout(pageName, tests)];

--- a/cypress/integration/productionTests/publicPaths/render/database/ngrams.spec.ts
+++ b/cypress/integration/productionTests/publicPaths/render/database/ngrams.spec.ts
@@ -1,3 +1,7 @@
+import {
+  tableExpectations,
+  testViewsSection,
+} from "cypress/integration/utils/sharedTests/repoDatabaseNav";
 import { runTestsForDevices } from "../../../../utils";
 import { macbook15ForAppLayout } from "../../../../utils/devices";
 import {
@@ -6,9 +10,9 @@ import {
   newExpectationWithClickFlows,
   newShouldArgs,
 } from "../../../../utils/helpers";
-import { testPaginationForRepoDataTable } from "../../../../utils/sharedTests/pagination";
+// import { testPaginationForRepoDataTable } from "../../../../utils/sharedTests/pagination";
 import { testRepoHeaderWithBranch } from "../../../../utils/sharedTests/repoHeaderNav";
-import { testSqlConsole } from "../../../../utils/sharedTests/sqlEditor";
+// import { testSqlConsole } from "../../../../utils/sharedTests/sqlEditor";
 
 const pageName = "Database page (wikipedia-ngrams) with tables";
 const currentOwner = "automated_testing";
@@ -16,6 +20,7 @@ const currentRepo = "wikipedia-ngrams";
 const currentPage = `repositories/${currentOwner}/${currentRepo}`;
 const loggedIn = false;
 const hasDocs = false;
+const hasBranch = true;
 
 const beVisible = newShouldArgs("be.visible");
 
@@ -62,7 +67,7 @@ describe(`${pageName} renders expected components on different devices`, () => {
       [tablesClickFlow],
     ),
     // testSchemasSection(4, "unigram_counts"),
-    // testViewsSection(0),
+
     newExpectation(
       "should find repo data",
       "[data-cy=repo-data-table-empty]",
@@ -78,8 +83,10 @@ describe(`${pageName} renders expected components on different devices`, () => {
       "[data-cy=repo-data-table-row-0-col-1]",
       newShouldArgs("be.visible.and.contain", "3071"),
     ),
-    ...testPaginationForRepoDataTable,
-    testSqlConsole,
+    ...tableExpectations(hasDocs, hasBranch, loggedIn, 4, "bigram_counts"),
+    testViewsSection(hasBranch, 0),
+    // ...testPaginationForRepoDataTable,
+    // testSqlConsole,
   ];
 
   const devices = [macbook15ForAppLayout(pageName, tests)];

--- a/cypress/integration/productionTests/publicPaths/render/database/ngrams.spec.ts
+++ b/cypress/integration/productionTests/publicPaths/render/database/ngrams.spec.ts
@@ -1,6 +1,7 @@
 import {
   tableExpectations,
   testViewsSection,
+  testQueryCatalogSection
 } from "cypress/integration/utils/sharedTests/repoDatabaseNav";
 import { runTestsForDevices } from "../../../../utils";
 import { macbook15ForAppLayout } from "../../../../utils/devices";
@@ -85,6 +86,7 @@ describe(`${pageName} renders expected components on different devices`, () => {
     ),
     ...tableExpectations(hasDocs, hasBranch, loggedIn, 4, "bigram_counts"),
     testViewsSection(hasBranch, 0),
+    testQueryCatalogSection(hasBranch, 0)
     // ...testPaginationForRepoDataTable,
     // testSqlConsole,
   ];

--- a/cypress/integration/productionTests/publicPaths/render/database/ngrams.spec.ts
+++ b/cypress/integration/productionTests/publicPaths/render/database/ngrams.spec.ts
@@ -1,7 +1,7 @@
 import {
   tableExpectations,
   testViewsSection,
-  testQueryCatalogSection
+  testQueryCatalogSection,
 } from "cypress/integration/utils/sharedTests/repoDatabaseNav";
 import { runTestsForDevices } from "../../../../utils";
 import { macbook15ForAppLayout } from "../../../../utils/devices";
@@ -86,7 +86,7 @@ describe(`${pageName} renders expected components on different devices`, () => {
     ),
     ...tableExpectations(hasDocs, hasBranch, loggedIn, 4, "bigram_counts"),
     testViewsSection(hasBranch, 0),
-    testQueryCatalogSection(hasBranch, 0)
+    testQueryCatalogSection(hasBranch, 0),
     // ...testPaginationForRepoDataTable,
     // testSqlConsole,
   ];

--- a/cypress/integration/productionTests/publicPaths/render/database/ngrams.spec.ts
+++ b/cypress/integration/productionTests/publicPaths/render/database/ngrams.spec.ts
@@ -2,7 +2,9 @@ import {
   tableExpectations,
   testViewsSection,
   testQueryCatalogSection,
+  testSchemaSection,
 } from "cypress/integration/utils/sharedTests/repoDatabaseNav";
+import { testSqlConsole } from "cypress/integration/utils/sharedTests/sqlEditor";
 import { runTestsForDevices } from "../../../../utils";
 import { macbook15ForAppLayout } from "../../../../utils/devices";
 import {
@@ -87,8 +89,9 @@ describe(`${pageName} renders expected components on different devices`, () => {
     ...tableExpectations(hasDocs, hasBranch, loggedIn, 4, "bigram_counts"),
     testViewsSection(hasBranch, 0),
     testQueryCatalogSection(hasBranch, 0),
+    testSchemaSection(hasBranch, 4, "bigram_counts"),
     // ...testPaginationForRepoDataTable,
-    // testSqlConsole,
+    testSqlConsole,
   ];
 
   const devices = [macbook15ForAppLayout(pageName, tests)];

--- a/cypress/integration/productionTests/publicPaths/render/database/ngrams.spec.ts
+++ b/cypress/integration/productionTests/publicPaths/render/database/ngrams.spec.ts
@@ -86,10 +86,10 @@ describe(`${pageName} renders expected components on different devices`, () => {
       newShouldArgs("be.visible.and.contain", "3071"),
     ),
     ...tableExpectations(hasDocs, hasBranch, loggedIn, 4, "bigram_counts"),
+    ...testPaginationForRepoDataTable,
     testViewsSection(hasBranch, 0),
     testQueryCatalogSection(hasBranch, 0),
     testSchemaSection(hasBranch, 4, "bigram_counts"),
-    ...testPaginationForRepoDataTable,
     testSqlConsole,
   ];
 

--- a/cypress/integration/productionTests/publicPaths/render/database/ngrams.spec.ts
+++ b/cypress/integration/productionTests/publicPaths/render/database/ngrams.spec.ts
@@ -27,7 +27,6 @@ const hasBranch = true;
 
 const beVisible = newShouldArgs("be.visible");
 
-// TODO: Test commented out sections for left nav
 describe(`${pageName} renders expected components on different devices`, () => {
   const tablesClickFlow = newClickFlow(
     "[data-cy=active-tab-tables]",

--- a/cypress/integration/productionTests/publicPaths/render/database/ngrams.spec.ts
+++ b/cypress/integration/productionTests/publicPaths/render/database/ngrams.spec.ts
@@ -13,7 +13,7 @@ import {
   newExpectationWithClickFlows,
   newShouldArgs,
 } from "../../../../utils/helpers";
-// import { testPaginationForRepoDataTable } from "../../../../utils/sharedTests/pagination";
+import { testPaginationForRepoDataTable } from "../../../../utils/sharedTests/pagination";
 import { testRepoHeaderWithBranch } from "../../../../utils/sharedTests/repoHeaderNav";
 // import { testSqlConsole } from "../../../../utils/sharedTests/sqlEditor";
 
@@ -69,7 +69,6 @@ describe(`${pageName} renders expected components on different devices`, () => {
       beVisible,
       [tablesClickFlow],
     ),
-    // testSchemasSection(4, "unigram_counts"),
 
     newExpectation(
       "should find repo data",
@@ -90,7 +89,7 @@ describe(`${pageName} renders expected components on different devices`, () => {
     testViewsSection(hasBranch, 0),
     testQueryCatalogSection(hasBranch, 0),
     testSchemaSection(hasBranch, 4, "bigram_counts"),
-    // ...testPaginationForRepoDataTable,
+    ...testPaginationForRepoDataTable,
     testSqlConsole,
   ];
 

--- a/cypress/integration/productionTests/publicPaths/render/database/ngrams.spec.ts
+++ b/cypress/integration/productionTests/publicPaths/render/database/ngrams.spec.ts
@@ -3,8 +3,8 @@ import {
   testViewsSection,
   testQueryCatalogSection,
   testSchemaSection,
-} from "cypress/integration/utils/sharedTests/repoDatabaseNav";
-import { testSqlConsole } from "cypress/integration/utils/sharedTests/sqlEditor";
+} from "../../../../utils/sharedTests/repoDatabaseNav";
+import { testSqlConsole } from "../../../../utils/sharedTests/sqlEditor";
 import { runTestsForDevices } from "../../../../utils";
 import { macbook15ForAppLayout } from "../../../../utils/devices";
 import {

--- a/cypress/integration/productionTests/publicPaths/render/database/tablesAndDocs.spec.ts
+++ b/cypress/integration/productionTests/publicPaths/render/database/tablesAndDocs.spec.ts
@@ -11,6 +11,7 @@ const currentRepo = "repo_tables_and_docs";
 const currentPage = `repositories/${currentOwner}/${currentRepo}`;
 const loggedIn = false;
 const hasDocs = true;
+const hasBranch = true;
 
 // TODO: Test commented out sections for left nav
 describe(`${pageName} renders expected components on different devices`, () => {
@@ -35,7 +36,7 @@ describe(`${pageName} renders expected components on different devices`, () => {
     ),
     ...testRepoHeaderWithBranch(currentRepo, currentOwner, loggedIn, hasDocs),
     // testAboutSection(true),
-    ...tableExpectations(1, "test_table"),
+    ...tableExpectations(hasBranch, 1, "test_table"),
     testSqlConsole,
     // testSchemasSection(1, "test_table"),
     // testViewsSection(0),

--- a/cypress/integration/productionTests/publicPaths/render/database/tablesAndDocs.spec.ts
+++ b/cypress/integration/productionTests/publicPaths/render/database/tablesAndDocs.spec.ts
@@ -1,3 +1,4 @@
+import { testSqlConsole } from "cypress/integration/utils/sharedTests/sqlEditor";
 import { runTestsForDevices } from "../../../../utils";
 import { macbook15ForAppLayout } from "../../../../utils/devices";
 import { newExpectation, newShouldArgs } from "../../../../utils/helpers";
@@ -5,6 +6,7 @@ import {
   tableExpectations,
   testViewsSection,
   testQueryCatalogSection,
+  testSchemaSection,
 } from "../../../../utils/sharedTests/repoDatabaseNav";
 import { testRepoHeaderWithBranch } from "../../../../utils/sharedTests/repoHeaderNav";
 // import { testSqlConsole } from "../../../../utils/sharedTests/sqlEditor";
@@ -42,9 +44,9 @@ describe(`${pageName} renders expected components on different devices`, () => {
     ...tableExpectations(true, hasBranch, loggedIn, 1, "test_table"),
     testViewsSection(hasBranch, 0),
     testQueryCatalogSection(hasBranch, 0),
+    testSchemaSection(hasBranch, 1, "test_table"),
+    testSqlConsole,
     // testAboutSection(true),
-    // testSqlConsole,
-    // testSchemasSection(1, "test_table"),
   ];
 
   const devices = [macbook15ForAppLayout(pageName, tests)];

--- a/cypress/integration/productionTests/publicPaths/render/database/tablesAndDocs.spec.ts
+++ b/cypress/integration/productionTests/publicPaths/render/database/tablesAndDocs.spec.ts
@@ -46,7 +46,6 @@ describe(`${pageName} renders expected components on different devices`, () => {
     testQueryCatalogSection(hasBranch, 0),
     testSchemaSection(hasBranch, 1, "test_table"),
     testSqlConsole,
-    // testAboutSection(true),
   ];
 
   const devices = [macbook15ForAppLayout(pageName, tests)];

--- a/cypress/integration/productionTests/publicPaths/render/database/tablesAndDocs.spec.ts
+++ b/cypress/integration/productionTests/publicPaths/render/database/tablesAndDocs.spec.ts
@@ -1,4 +1,4 @@
-import { testSqlConsole } from "cypress/integration/utils/sharedTests/sqlEditor";
+import { testSqlConsole } from "../../../../utils/sharedTests/sqlEditor";
 import { runTestsForDevices } from "../../../../utils";
 import { macbook15ForAppLayout } from "../../../../utils/devices";
 import { newExpectation, newShouldArgs } from "../../../../utils/helpers";

--- a/cypress/integration/productionTests/publicPaths/render/database/tablesAndDocs.spec.ts
+++ b/cypress/integration/productionTests/publicPaths/render/database/tablesAndDocs.spec.ts
@@ -36,7 +36,7 @@ describe(`${pageName} renders expected components on different devices`, () => {
     ),
     ...testRepoHeaderWithBranch(currentRepo, currentOwner, loggedIn, hasDocs),
     // testAboutSection(true),
-    ...tableExpectations(hasBranch, 1, "test_table"),
+    ...tableExpectations(hasBranch, loggedIn, 1, "test_table"),
     testSqlConsole,
     // testSchemasSection(1, "test_table"),
     // testViewsSection(0),

--- a/cypress/integration/productionTests/publicPaths/render/database/tablesAndDocs.spec.ts
+++ b/cypress/integration/productionTests/publicPaths/render/database/tablesAndDocs.spec.ts
@@ -4,6 +4,7 @@ import { newExpectation, newShouldArgs } from "../../../../utils/helpers";
 import {
   tableExpectations,
   testViewsSection,
+  testQueryCatalogSection
 } from "../../../../utils/sharedTests/repoDatabaseNav";
 import { testRepoHeaderWithBranch } from "../../../../utils/sharedTests/repoHeaderNav";
 // import { testSqlConsole } from "../../../../utils/sharedTests/sqlEditor";
@@ -40,10 +41,10 @@ describe(`${pageName} renders expected components on different devices`, () => {
     ...testRepoHeaderWithBranch(currentRepo, currentOwner, loggedIn, hasDocs),
     ...tableExpectations(true, hasBranch, loggedIn, 1, "test_table"),
     testViewsSection(hasBranch, 0),
+    testQueryCatalogSection(hasBranch, 0),
     // testAboutSection(true),
     // testSqlConsole,
     // testSchemasSection(1, "test_table"),
-    // testQueryCatalogSection(0),
   ];
 
   const devices = [macbook15ForAppLayout(pageName, tests)];

--- a/cypress/integration/productionTests/publicPaths/render/database/tablesAndDocs.spec.ts
+++ b/cypress/integration/productionTests/publicPaths/render/database/tablesAndDocs.spec.ts
@@ -1,9 +1,12 @@
 import { runTestsForDevices } from "../../../../utils";
 import { macbook15ForAppLayout } from "../../../../utils/devices";
 import { newExpectation, newShouldArgs } from "../../../../utils/helpers";
-import { tableExpectations } from "../../../../utils/sharedTests/repoDatabaseNav";
+import {
+  tableExpectations,
+  testViewsSection,
+} from "../../../../utils/sharedTests/repoDatabaseNav";
 import { testRepoHeaderWithBranch } from "../../../../utils/sharedTests/repoHeaderNav";
-import { testSqlConsole } from "../../../../utils/sharedTests/sqlEditor";
+// import { testSqlConsole } from "../../../../utils/sharedTests/sqlEditor";
 
 const pageName = "Database page with tables and docs";
 const currentOwner = "automated_testing";
@@ -35,11 +38,11 @@ describe(`${pageName} renders expected components on different devices`, () => {
       beVisible,
     ),
     ...testRepoHeaderWithBranch(currentRepo, currentOwner, loggedIn, hasDocs),
+    ...tableExpectations(true, hasBranch, loggedIn, 1, "test_table"),
+    testViewsSection(hasBranch, 0),
     // testAboutSection(true),
-    ...tableExpectations(hasBranch, loggedIn, 1, "test_table"),
-    testSqlConsole,
+    // testSqlConsole,
     // testSchemasSection(1, "test_table"),
-    // testViewsSection(0),
     // testQueryCatalogSection(0),
   ];
 

--- a/cypress/integration/productionTests/publicPaths/render/database/tablesAndDocs.spec.ts
+++ b/cypress/integration/productionTests/publicPaths/render/database/tablesAndDocs.spec.ts
@@ -9,7 +9,6 @@ import {
   testSchemaSection,
 } from "../../../../utils/sharedTests/repoDatabaseNav";
 import { testRepoHeaderWithBranch } from "../../../../utils/sharedTests/repoHeaderNav";
-// import { testSqlConsole } from "../../../../utils/sharedTests/sqlEditor";
 
 const pageName = "Database page with tables and docs";
 const currentOwner = "automated_testing";
@@ -19,7 +18,6 @@ const loggedIn = false;
 const hasDocs = true;
 const hasBranch = true;
 
-// TODO: Test commented out sections for left nav
 describe(`${pageName} renders expected components on different devices`, () => {
   const beVisible = newShouldArgs("be.visible");
   const notExist = newShouldArgs("not.exist");

--- a/cypress/integration/productionTests/publicPaths/render/database/tablesAndDocs.spec.ts
+++ b/cypress/integration/productionTests/publicPaths/render/database/tablesAndDocs.spec.ts
@@ -4,7 +4,7 @@ import { newExpectation, newShouldArgs } from "../../../../utils/helpers";
 import {
   tableExpectations,
   testViewsSection,
-  testQueryCatalogSection
+  testQueryCatalogSection,
 } from "../../../../utils/sharedTests/repoDatabaseNav";
 import { testRepoHeaderWithBranch } from "../../../../utils/sharedTests/repoHeaderNav";
 // import { testSqlConsole } from "../../../../utils/sharedTests/sqlEditor";

--- a/cypress/integration/productionTests/publicPaths/render/database/tablesNoDocs.spec.ts
+++ b/cypress/integration/productionTests/publicPaths/render/database/tablesNoDocs.spec.ts
@@ -1,7 +1,7 @@
 import {
   tableExpectations,
   testViewsSection,
-  testQueryCatalogSection
+  testQueryCatalogSection,
 } from "cypress/integration/utils/sharedTests/repoDatabaseNav";
 import { runTestsForDevices } from "../../../../utils";
 import { macbook15ForAppLayout } from "../../../../utils/devices";
@@ -52,7 +52,7 @@ describe(`${pageName} renders expected components on different devices`, () => {
     ),
     ...tableExpectations(hasDocs, hasBranch, loggedIn, 1, "test_table"),
     testViewsSection(hasBranch, 0),
-    testQueryCatalogSection(hasBranch, 0)
+    testQueryCatalogSection(hasBranch, 0),
   ];
 
   const devices = [macbook15ForAppLayout(pageName, tests)];

--- a/cypress/integration/productionTests/publicPaths/render/database/tablesNoDocs.spec.ts
+++ b/cypress/integration/productionTests/publicPaths/render/database/tablesNoDocs.spec.ts
@@ -2,7 +2,9 @@ import {
   tableExpectations,
   testViewsSection,
   testQueryCatalogSection,
+  testSchemaSection,
 } from "cypress/integration/utils/sharedTests/repoDatabaseNav";
+import { testSqlConsole } from "cypress/integration/utils/sharedTests/sqlEditor";
 import { runTestsForDevices } from "../../../../utils";
 import { macbook15ForAppLayout } from "../../../../utils/devices";
 import { newExpectation, newShouldArgs } from "../../../../utils/helpers";
@@ -53,6 +55,8 @@ describe(`${pageName} renders expected components on different devices`, () => {
     ...tableExpectations(hasDocs, hasBranch, loggedIn, 1, "test_table"),
     testViewsSection(hasBranch, 0),
     testQueryCatalogSection(hasBranch, 0),
+    testSchemaSection(hasBranch, 1, "test_table"),
+    testSqlConsole,
   ];
 
   const devices = [macbook15ForAppLayout(pageName, tests)];

--- a/cypress/integration/productionTests/publicPaths/render/database/tablesNoDocs.spec.ts
+++ b/cypress/integration/productionTests/publicPaths/render/database/tablesNoDocs.spec.ts
@@ -3,8 +3,8 @@ import {
   testViewsSection,
   testQueryCatalogSection,
   testSchemaSection,
-} from "cypress/integration/utils/sharedTests/repoDatabaseNav";
-import { testSqlConsole } from "cypress/integration/utils/sharedTests/sqlEditor";
+} from "../../../../utils/sharedTests/repoDatabaseNav";
+import { testSqlConsole } from "../../../../utils/sharedTests/sqlEditor";
 import { runTestsForDevices } from "../../../../utils";
 import { macbook15ForAppLayout } from "../../../../utils/devices";
 import { newExpectation, newShouldArgs } from "../../../../utils/helpers";

--- a/cypress/integration/productionTests/publicPaths/render/database/tablesNoDocs.spec.ts
+++ b/cypress/integration/productionTests/publicPaths/render/database/tablesNoDocs.spec.ts
@@ -1,6 +1,7 @@
 import {
   tableExpectations,
   testViewsSection,
+  testQueryCatalogSection
 } from "cypress/integration/utils/sharedTests/repoDatabaseNav";
 import { runTestsForDevices } from "../../../../utils";
 import { macbook15ForAppLayout } from "../../../../utils/devices";
@@ -51,6 +52,7 @@ describe(`${pageName} renders expected components on different devices`, () => {
     ),
     ...tableExpectations(hasDocs, hasBranch, loggedIn, 1, "test_table"),
     testViewsSection(hasBranch, 0),
+    testQueryCatalogSection(hasBranch, 0)
   ];
 
   const devices = [macbook15ForAppLayout(pageName, tests)];

--- a/cypress/integration/productionTests/publicPaths/render/database/tablesNoDocs.spec.ts
+++ b/cypress/integration/productionTests/publicPaths/render/database/tablesNoDocs.spec.ts
@@ -9,7 +9,6 @@ import { runTestsForDevices } from "../../../../utils";
 import { macbook15ForAppLayout } from "../../../../utils/devices";
 import { newExpectation, newShouldArgs } from "../../../../utils/helpers";
 import { testRepoHeaderWithBranch } from "../../../../utils/sharedTests/repoHeaderNav";
-// import { testSqlConsole } from "../../../../utils/sharedTests/sqlEditor";
 
 const pageName = "Database page with tables and no docs";
 const currentOwner = "automated_testing";
@@ -25,7 +24,6 @@ describe(`${pageName} renders expected components on different devices`, () => {
 
   // TODO: Add tests for left side database navigation
   const tests = [
-    // testSqlConsole,
     ...testRepoHeaderWithBranch(currentRepo, currentOwner, loggedIn, hasDocs),
     newExpectation(
       "should not find empty database",

--- a/cypress/integration/productionTests/publicPaths/render/database/tablesNoDocs.spec.ts
+++ b/cypress/integration/productionTests/publicPaths/render/database/tablesNoDocs.spec.ts
@@ -22,7 +22,6 @@ describe(`${pageName} renders expected components on different devices`, () => {
   const beVisible = newShouldArgs("be.visible");
   const notExist = newShouldArgs("not.exist");
 
-  // TODO: Add tests for left side database navigation
   const tests = [
     ...testRepoHeaderWithBranch(currentRepo, currentOwner, loggedIn, hasDocs),
     newExpectation(

--- a/cypress/integration/productionTests/publicPaths/render/database/tablesNoDocs.spec.ts
+++ b/cypress/integration/productionTests/publicPaths/render/database/tablesNoDocs.spec.ts
@@ -1,8 +1,12 @@
+import {
+  tableExpectations,
+  testViewsSection,
+} from "cypress/integration/utils/sharedTests/repoDatabaseNav";
 import { runTestsForDevices } from "../../../../utils";
 import { macbook15ForAppLayout } from "../../../../utils/devices";
 import { newExpectation, newShouldArgs } from "../../../../utils/helpers";
 import { testRepoHeaderWithBranch } from "../../../../utils/sharedTests/repoHeaderNav";
-import { testSqlConsole } from "../../../../utils/sharedTests/sqlEditor";
+// import { testSqlConsole } from "../../../../utils/sharedTests/sqlEditor";
 
 const pageName = "Database page with tables and no docs";
 const currentOwner = "automated_testing";
@@ -10,6 +14,7 @@ const currentRepo = "repo_tables_no_docs";
 const currentPage = `repositories/${currentOwner}/${currentRepo}`;
 const loggedIn = false;
 const hasDocs = false;
+const hasBranch = true;
 
 describe(`${pageName} renders expected components on different devices`, () => {
   const beVisible = newShouldArgs("be.visible");
@@ -17,7 +22,7 @@ describe(`${pageName} renders expected components on different devices`, () => {
 
   // TODO: Add tests for left side database navigation
   const tests = [
-    testSqlConsole,
+    // testSqlConsole,
     ...testRepoHeaderWithBranch(currentRepo, currentOwner, loggedIn, hasDocs),
     newExpectation(
       "should not find empty database",
@@ -44,6 +49,8 @@ describe(`${pageName} renders expected components on different devices`, () => {
       "[data-cy=repo-data-table-row-0-col-1]",
       newShouldArgs("be.visible.and.contain", "b"),
     ),
+    ...tableExpectations(hasDocs, hasBranch, loggedIn, 1, "test_table"),
+    testViewsSection(hasBranch, 0),
   ];
 
   const devices = [macbook15ForAppLayout(pageName, tests)];

--- a/cypress/integration/productionTests/publicPaths/render/database/tags.spec.ts
+++ b/cypress/integration/productionTests/publicPaths/render/database/tags.spec.ts
@@ -14,7 +14,6 @@ import {
   testSchemaSection,
 } from "../../../../utils/sharedTests/repoDatabaseNav";
 import { testRepoHeaderWithBranch } from "../../../../utils/sharedTests/repoHeaderNav";
-// import { testSqlConsole } from "../../../../utils/sharedTests/sqlEditor";
 import { Expectation } from "../../../../utils/types";
 
 const pageName = "Database page with tags and branches";
@@ -26,7 +25,6 @@ const loggedIn = false;
 const hasBranch = true;
 const hasDocs = true;
 
-// TODO: Test commented out sections for left nav
 describe(`${pageName} renders expected components on different devices`, () => {
   const currentPage = `repositories/${currentOwner}/${currentRepo}`;
 
@@ -48,72 +46,6 @@ describe(`${pageName} renders expected components on different devices`, () => {
   const skip = false;
   runTestsForDevices({ currentPage, devices, skip });
 });
-
-// `repo_with_tags_and_branches` was made for testing
-// tags and branches as refs on Dolthub.
-// It has one table:
-//
-//  CREATE TABLE `test` (
-//     `pk` INT NOT NULL,
-//     `note` LONGTEXT,
-//     PRIMARY KEY (`pk`)
-//   );
-//
-// It has 4 branches:
-//
-//   fifteen
-//   five
-// * master
-//   ten
-//
-// It has 21 tags:
-//
-//	v20
-// 	v19
-//  ...
-// 	v1
-// 	start
-//
-// It has 23 commits:
-//
-// commit 7rj0pd2srpftde0qh6ocjqo6ts0v5d1g
-// Author: Andy Arthur <andy@liquidata.co>
-// Date:   Wed Sep 09 12:46:54 -0700 2020
-//
-// 	added README
-//
-// commit 44em5msekdb4mj32g4ocaos6usodkmr9
-// Author: Andy Arthur <andy@liquidata.co>
-// Date:   Wed Sep 09 12:36:52 -0700 2020
-//
-// 	added row with value 20
-//
-// commit 16ohpemh3ta66tdeb28ntildr3dcuacv
-// Author: Andy Arthur <andy@liquidata.co>
-// Date:   Wed Sep 09 12:36:52 -0700 2020
-//
-// 	added row with value 19
-//
-// ...
-//
-// commit 0ngbhk163gbu4d6te9fdocu0tdbs6ir7
-// Author: Andy Arthur <andy@liquidata.co>
-// Date:   Wed Sep 09 12:36:49 -0700 2020
-//
-// 	added row with value 1
-//
-// commit idugn19r85qctvr6kks23i839dvqe2q8
-// Author: Andy Arthur <andy@liquidata.co>
-// Date:   Wed Sep 09 12:28:54 -0700 2020
-//
-// 	created table test
-//
-// commit 2blr4m6bu996vgv273febvn20qdathat
-// Author: Andy Arthur <andy@liquidata.co>
-// Date:   Wed Sep 09 12:27:17 -0700 2020
-//
-// 	Initialize data repository
-//
 
 export const testReleasesSection = (tagLen: number): Expectation =>
   newExpectationWithClickFlows(

--- a/cypress/integration/productionTests/publicPaths/render/database/tags.spec.ts
+++ b/cypress/integration/productionTests/publicPaths/render/database/tags.spec.ts
@@ -6,9 +6,12 @@ import {
   newExpectationWithClickFlows,
   newShouldArgs,
 } from "../../../../utils/helpers";
-import { tableExpectations } from "../../../../utils/sharedTests/repoDatabaseNav";
+import {
+  tableExpectations,
+  testViewsSection,
+} from "../../../../utils/sharedTests/repoDatabaseNav";
 import { testRepoHeaderWithBranch } from "../../../../utils/sharedTests/repoHeaderNav";
-import { testSqlConsole } from "../../../../utils/sharedTests/sqlEditor";
+// import { testSqlConsole } from "../../../../utils/sharedTests/sqlEditor";
 import { Expectation } from "../../../../utils/types";
 
 const pageName = "Database page with tags and branches";
@@ -18,6 +21,7 @@ const currentRepo = "repo_with_tags_and_branches";
 const notExist = newShouldArgs("not.exist");
 const loggedIn = false;
 const hasBranch = true;
+const hasDocs = true;
 
 // TODO: Test commented out sections for left nav
 describe(`${pageName} renders expected components on different devices`, () => {
@@ -30,10 +34,10 @@ describe(`${pageName} renders expected components on different devices`, () => {
       notExist,
     ),
     ...testRepoHeaderWithBranch(currentRepo, currentOwner, loggedIn, false),
+    ...tableExpectations(hasDocs, hasBranch, loggedIn, 1, "test"),
+    testViewsSection(hasBranch, 0),
     // testAboutSection(true),
-    ...tableExpectations(hasBranch, loggedIn, 1, "test"),
-    testSqlConsole,
-    // testViewsSection(0),
+    // testSqlConsole,
     // testQueryCatalogSection(0),
   ];
 

--- a/cypress/integration/productionTests/publicPaths/render/database/tags.spec.ts
+++ b/cypress/integration/productionTests/publicPaths/render/database/tags.spec.ts
@@ -17,6 +17,7 @@ const currentRepo = "repo_with_tags_and_branches";
 
 const notExist = newShouldArgs("not.exist");
 const loggedIn = false;
+const hasBranch = true;
 
 // TODO: Test commented out sections for left nav
 describe(`${pageName} renders expected components on different devices`, () => {
@@ -30,7 +31,7 @@ describe(`${pageName} renders expected components on different devices`, () => {
     ),
     ...testRepoHeaderWithBranch(currentRepo, currentOwner, loggedIn, false),
     // testAboutSection(true),
-    ...tableExpectations(1, "test"),
+    ...tableExpectations(hasBranch, 1, "test"),
     testSqlConsole,
     // testViewsSection(0),
     // testQueryCatalogSection(0),

--- a/cypress/integration/productionTests/publicPaths/render/database/tags.spec.ts
+++ b/cypress/integration/productionTests/publicPaths/render/database/tags.spec.ts
@@ -1,3 +1,4 @@
+import { testSqlConsole } from "cypress/integration/utils/sharedTests/sqlEditor";
 import { runTestsForDevices } from "../../../../utils";
 import { macbook15ForAppLayout } from "../../../../utils/devices";
 import {
@@ -10,6 +11,7 @@ import {
   tableExpectations,
   testViewsSection,
   testQueryCatalogSection,
+  testSchemaSection,
 } from "../../../../utils/sharedTests/repoDatabaseNav";
 import { testRepoHeaderWithBranch } from "../../../../utils/sharedTests/repoHeaderNav";
 // import { testSqlConsole } from "../../../../utils/sharedTests/sqlEditor";
@@ -38,8 +40,9 @@ describe(`${pageName} renders expected components on different devices`, () => {
     ...tableExpectations(hasDocs, hasBranch, loggedIn, 1, "test"),
     testViewsSection(hasBranch, 0),
     testQueryCatalogSection(hasBranch, 0),
+    testSchemaSection(hasBranch, 1, "test"),
+    testSqlConsole,
     // testAboutSection(true),
-    // testSqlConsole,
   ];
 
   const devices = [macbook15ForAppLayout(pageName, tests)];

--- a/cypress/integration/productionTests/publicPaths/render/database/tags.spec.ts
+++ b/cypress/integration/productionTests/publicPaths/render/database/tags.spec.ts
@@ -31,7 +31,7 @@ describe(`${pageName} renders expected components on different devices`, () => {
     ),
     ...testRepoHeaderWithBranch(currentRepo, currentOwner, loggedIn, false),
     // testAboutSection(true),
-    ...tableExpectations(hasBranch, 1, "test"),
+    ...tableExpectations(hasBranch, loggedIn, 1, "test"),
     testSqlConsole,
     // testViewsSection(0),
     // testQueryCatalogSection(0),

--- a/cypress/integration/productionTests/publicPaths/render/database/tags.spec.ts
+++ b/cypress/integration/productionTests/publicPaths/render/database/tags.spec.ts
@@ -42,7 +42,6 @@ describe(`${pageName} renders expected components on different devices`, () => {
     testQueryCatalogSection(hasBranch, 0),
     testSchemaSection(hasBranch, 1, "test"),
     testSqlConsole,
-    // testAboutSection(true),
   ];
 
   const devices = [macbook15ForAppLayout(pageName, tests)];

--- a/cypress/integration/productionTests/publicPaths/render/database/tags.spec.ts
+++ b/cypress/integration/productionTests/publicPaths/render/database/tags.spec.ts
@@ -9,6 +9,7 @@ import {
 import {
   tableExpectations,
   testViewsSection,
+  testQueryCatalogSection
 } from "../../../../utils/sharedTests/repoDatabaseNav";
 import { testRepoHeaderWithBranch } from "../../../../utils/sharedTests/repoHeaderNav";
 // import { testSqlConsole } from "../../../../utils/sharedTests/sqlEditor";
@@ -36,9 +37,9 @@ describe(`${pageName} renders expected components on different devices`, () => {
     ...testRepoHeaderWithBranch(currentRepo, currentOwner, loggedIn, false),
     ...tableExpectations(hasDocs, hasBranch, loggedIn, 1, "test"),
     testViewsSection(hasBranch, 0),
+    testQueryCatalogSection(hasBranch, 0),
     // testAboutSection(true),
     // testSqlConsole,
-    // testQueryCatalogSection(0),
   ];
 
   const devices = [macbook15ForAppLayout(pageName, tests)];

--- a/cypress/integration/productionTests/publicPaths/render/database/tags.spec.ts
+++ b/cypress/integration/productionTests/publicPaths/render/database/tags.spec.ts
@@ -9,7 +9,7 @@ import {
 import {
   tableExpectations,
   testViewsSection,
-  testQueryCatalogSection
+  testQueryCatalogSection,
 } from "../../../../utils/sharedTests/repoDatabaseNav";
 import { testRepoHeaderWithBranch } from "../../../../utils/sharedTests/repoHeaderNav";
 // import { testSqlConsole } from "../../../../utils/sharedTests/sqlEditor";

--- a/cypress/integration/productionTests/publicPaths/render/database/tags.spec.ts
+++ b/cypress/integration/productionTests/publicPaths/render/database/tags.spec.ts
@@ -1,4 +1,4 @@
-import { testSqlConsole } from "cypress/integration/utils/sharedTests/sqlEditor";
+import { testSqlConsole } from "../../../../utils/sharedTests/sqlEditor";
 import { runTestsForDevices } from "../../../../utils";
 import { macbook15ForAppLayout } from "../../../../utils/devices";
 import {

--- a/cypress/integration/productionTests/publicPaths/render/database/tags.spec.ts
+++ b/cypress/integration/productionTests/publicPaths/render/database/tags.spec.ts
@@ -47,6 +47,72 @@ describe(`${pageName} renders expected components on different devices`, () => {
   runTestsForDevices({ currentPage, devices, skip });
 });
 
+// `repo_with_tags_and_branches` was made for testing
+// tags and branches as refs on Dolthub.
+// It has one table:
+//
+//  CREATE TABLE `test` (
+//     `pk` INT NOT NULL,
+//     `note` LONGTEXT,
+//     PRIMARY KEY (`pk`)
+//   );
+//
+// It has 4 branches:
+//
+//   fifteen
+//   five
+// * master
+//   ten
+//
+// It has 21 tags:
+//
+//	v20
+// 	v19
+//  ...
+// 	v1
+// 	start
+//
+// It has 23 commits:
+//
+// commit 7rj0pd2srpftde0qh6ocjqo6ts0v5d1g
+// Author: Andy Arthur <andy@liquidata.co>
+// Date:   Wed Sep 09 12:46:54 -0700 2020
+//
+// 	added README
+//
+// commit 44em5msekdb4mj32g4ocaos6usodkmr9
+// Author: Andy Arthur <andy@liquidata.co>
+// Date:   Wed Sep 09 12:36:52 -0700 2020
+//
+// 	added row with value 20
+//
+// commit 16ohpemh3ta66tdeb28ntildr3dcuacv
+// Author: Andy Arthur <andy@liquidata.co>
+// Date:   Wed Sep 09 12:36:52 -0700 2020
+//
+// 	added row with value 19
+//
+// ...
+//
+// commit 0ngbhk163gbu4d6te9fdocu0tdbs6ir7
+// Author: Andy Arthur <andy@liquidata.co>
+// Date:   Wed Sep 09 12:36:49 -0700 2020
+//
+// 	added row with value 1
+//
+// commit idugn19r85qctvr6kks23i839dvqe2q8
+// Author: Andy Arthur <andy@liquidata.co>
+// Date:   Wed Sep 09 12:28:54 -0700 2020
+//
+// 	created table test
+//
+// commit 2blr4m6bu996vgv273febvn20qdathat
+// Author: Andy Arthur <andy@liquidata.co>
+// Date:   Wed Sep 09 12:27:17 -0700 2020
+//
+// 	Initialize data repository
+//
+
 export const testReleasesSection = (tagLen: number): Expectation =>
   newExpectationWithClickFlows(
     "should have database Tag List section",

--- a/cypress/integration/utils/sharedTests/repoDatabaseNav.ts
+++ b/cypress/integration/utils/sharedTests/repoDatabaseNav.ts
@@ -141,23 +141,26 @@ export const conditionalPlayButtonTest = (
   testTable: string,
 ) => {
   const playExpectation: Tests = hasDocs
-    ? [newExpectationWithClickFlows(
-        `should have test table ${testTable}`,
-        `[data-cy=repo-tables-table-${testTable}]`,
-        beVisible,
-        [testTablePlayClickFlow(testTable)],
-      )]
-    : [newExpectation(
-        "Should show a list of columns",
-        `[data-cy=repo-tables-table-${testTable}-column-list]`,
-        beVisible,
-      ),
-      newExpectation(
-        "Should show 'viewing'",
-        `[data-cy=repo-tables-table-viewing]`,
-        newShouldArgs("be.visible.and.contain", "Viewing"),
-      ),
-    ]
+    ? [
+        newExpectationWithClickFlows(
+          `should have test table ${testTable}`,
+          `[data-cy=repo-tables-table-${testTable}]`,
+          beVisible,
+          [testTablePlayClickFlow(testTable)],
+        ),
+      ]
+    : [
+        newExpectation(
+          "Should show a list of columns",
+          `[data-cy=repo-tables-table-${testTable}-column-list]`,
+          beVisible,
+        ),
+        newExpectation(
+          "Should show 'viewing'",
+          `[data-cy=repo-tables-table-viewing]`,
+          newShouldArgs("be.visible.and.contain", "Viewing"),
+        ),
+      ];
 
   return playExpectation;
 };
@@ -440,10 +443,7 @@ const queryCatalogClickFlow = (
       ? [emptyQueriesExpectation(hasBranch)]
       : notEmptyQueriesExpectations(queryLen, testQuery);
 
-  return newClickFlow(
-    "[data-cy=tab-queries]",
-    expectations,
-  );
+  return newClickFlow("[data-cy=tab-queries]", expectations);
 };
 
 export const testQueryCatalogSection = (
@@ -458,7 +458,7 @@ export const testQueryCatalogSection = (
     "should have repo Query Catalog section",
     "[data-cy=tab-queries]",
     beVisible,
-    [queryCatalogClickFlow(hasBranch,queryLen, testQuery)],
+    [queryCatalogClickFlow(hasBranch, queryLen, testQuery)],
   );
 };
 

--- a/cypress/integration/utils/sharedTests/repoDatabaseNav.ts
+++ b/cypress/integration/utils/sharedTests/repoDatabaseNav.ts
@@ -79,7 +79,21 @@ const testTablePlayClickFlow = (testTable: string): ClickFlow =>
       `[data-cy=repo-tables-table-${testTable}-column-list]`,
       beVisible,
     ),
+    newExpectation(
+      "",
+      `[data-cy=repo-tables-table-viewing]`,
+      newShouldArgs("be.visible.and.contain", "Viewing"),
+    ),
   ]);
+
+  // const testTableEditClickFlow = (testTable: string): ClickFlow =>
+  // newClickFlow(`[data-cy=repo-tables-table-${testTable}-edit]`, [
+  //   newExpectation(
+  //     "",
+  //     `[data-cy=repo-tables-table-${testTable}-column-list]`,
+  //     beVisible,
+  //   ),
+  // ]);
 
 const emptyTablesExpectation = [
   newExpectation(
@@ -102,7 +116,7 @@ const notEmptyTableExpectations = (
     `should have test table ${testTable}`,
     `[data-cy=repo-tables-table-${testTable}]`,
     beVisible,
-    [testTablePlayClickFlow(testTable)],
+    [testTablePlayClickFlow(testTable), ],
   ),
   // WRITE MORE TABLE TESTS HERE
   //
@@ -352,3 +366,5 @@ export const testQueryCatalogSection = (
     [queryCatalogClickFlow(queryLen, testQuery)],
   );
 };
+
+// KATIE WRITE SCHEMAS TESTS, ALL

--- a/cypress/integration/utils/sharedTests/repoDatabaseNav.ts
+++ b/cypress/integration/utils/sharedTests/repoDatabaseNav.ts
@@ -264,13 +264,11 @@ const testViewClickFlow = (testView: string): ClickFlow =>
     ),
   ]);
 
-export const emptyViewsExpectation = (hasBranch: boolean) => {
-  const viewsExpectation: Expectation = hasBranch
-    ? newExpectation("", "[data-cy=repo-no-views]", beVisible)
-    : newExpectation("", "[data-cy=repo-views-empty]", beVisible);
-
-  return viewsExpectation;
-};
+export const emptyViewsExpectation = (hasBranch: boolean): Expectation => (
+  hasBranch
+  ? newExpectation("", "[data-cy=repo-no-views]", beVisible)
+  : newExpectation("", "[data-cy=repo-views-empty]", beVisible)
+)
 
 const notEmptyViewsExpectations = (
   viewsLen: number,
@@ -334,13 +332,11 @@ const testQueryClickFlow = (testQuery: string): ClickFlow =>
     ),
   ]);
 
-export const emptyQueriesExpectation = (hasBranch: boolean) => {
-  const queriesExpectation: Expectation = hasBranch
+export const emptyQueriesExpectation = (hasBranch: boolean): Expection => (
+  hasBranch
     ? newExpectation("", "[data-cy=repo-no-queries]", beVisible)
-    : newExpectation("", "[data-cy=repo-queries-empty]", beVisible);
-
-  return queriesExpectation;
-};
+    : newExpectation("", "[data-cy=repo-queries-empty]", beVisible)
+);
 
 const notEmptyQueriesExpectations = (
   queryLen: number,
@@ -413,13 +409,11 @@ const testSchemaClickFlow = (testSchema: string): ClickFlow =>
     ),
   ]);
 
-export const emptySchemaExpectation = (hasBranch: boolean) => {
-  const schemaExpectation: Expectation = hasBranch
+export const emptySchemaExpectation = (hasBranch: boolean): Expectation => (  
+  hasBranch
     ? newExpectation("", "[data-cy=repo-tables-empty]", beVisible)
-    : newExpectation("", "[data-cy=repo-schemas-empty]", beVisible);
+    : newExpectation("", "[data-cy=repo-schemas-empty]", beVisible))
 
-  return schemaExpectation;
-};
 
 const notEmptySchemaExpectations = (
   schemaLen: number,

--- a/cypress/integration/utils/sharedTests/repoDatabaseNav.ts
+++ b/cypress/integration/utils/sharedTests/repoDatabaseNav.ts
@@ -189,8 +189,11 @@ const notEmptyTableExpectations = (
   ...conditionalPlayButtonTest(hasDocs, testTable),
   conditionalEditButtonTest(loggedIn, testTable),
   conditionalBranchTest(hasBranch),
-  // WRITE MORE TABLE TESTS HERE
-  //
+  newExpectation(
+    "",
+    "[data-cy=sql-editor-collapsed]",
+    newShouldArgs("be.visible.and.contain", `SELECT * FROM ${testTable}`),
+  ),
 ];
 
 //* Use tableExpectations when table is populated (left nav is initially open)
@@ -450,7 +453,11 @@ const schemaClickFlow = (
       ? [emptySchemaExpectation(hasBranch)]
       : notEmptySchemaExpectations(schemaLen, testSchema);
 
-  return newClickFlow("[data-cy=tab-schemas]", expectations, "[data-cy=tab-tables]");
+  return newClickFlow(
+    "[data-cy=tab-schemas]",
+    expectations,
+    "[data-cy=tab-tables]",
+  );
 };
 
 export const testSchemaSection = (

--- a/cypress/integration/utils/sharedTests/repoDatabaseNav.ts
+++ b/cypress/integration/utils/sharedTests/repoDatabaseNav.ts
@@ -189,11 +189,6 @@ const notEmptyTableExpectations = (
   ...conditionalPlayButtonTest(hasDocs, testTable),
   conditionalEditButtonTest(loggedIn, testTable),
   conditionalBranchTest(hasBranch),
-  newExpectation(
-    "",
-    "[data-cy=sql-editor-collapsed]",
-    newShouldArgs("be.visible.and.contain", `SELECT * FROM ${testTable}`),
-  ),
 ];
 
 //* Use tableExpectations when table is populated (left nav is initially open)

--- a/cypress/integration/utils/sharedTests/repoDatabaseNav.ts
+++ b/cypress/integration/utils/sharedTests/repoDatabaseNav.ts
@@ -405,10 +405,10 @@ export const testQueryCatalogSection = (
 // SCHEMAS
 
 const testSchemaClickFlow = (testSchema: string): ClickFlow =>
-  newClickFlow(`[data-cy=repo-schema-button-${testSchema}]`, [
+  newClickFlow(`[data-cy=repo-tables-schema-${testSchema}-play]`, [
     newExpectation(
       "",
-      `[data-cy=repo-schema-viewing-${testSchema}]`,
+      `[data-cy=repo-tables-schema-${testSchema}]`,
       newShouldArgs("be.visible.and.contain", "Viewing"),
     ),
     newExpectation(
@@ -420,7 +420,7 @@ const testSchemaClickFlow = (testSchema: string): ClickFlow =>
 
 export const emptySchemaExpectation = (hasBranch: boolean) => {
   const schemaExpectation: Expectation = hasBranch
-    ? newExpectation("", "[data-cy=repo-no-schemas]", beVisible)
+    ? newExpectation("", "[data-cy=repo-tables-empty]", beVisible)
     : newExpectation("", "[data-cy=repo-schemas-empty]", beVisible);
 
   return schemaExpectation;
@@ -437,7 +437,7 @@ const notEmptySchemaExpectations = (
   ),
   newExpectationWithClickFlows(
     "should successfully execute a schema",
-    `[data-cy=repo-schema-list-schema-${testSchema}]`,
+    `[data-cy=repo-tables-schema-${testSchema}]`,
     beVisible,
     [testSchemaClickFlow(testSchema)],
   ),

--- a/cypress/integration/utils/sharedTests/repoDatabaseNav.ts
+++ b/cypress/integration/utils/sharedTests/repoDatabaseNav.ts
@@ -264,11 +264,10 @@ const testViewClickFlow = (testView: string): ClickFlow =>
     ),
   ]);
 
-export const emptyViewsExpectation = (hasBranch: boolean): Expectation => (
+export const emptyViewsExpectation = (hasBranch: boolean): Expectation =>
   hasBranch
-  ? newExpectation("", "[data-cy=repo-no-views]", beVisible)
-  : newExpectation("", "[data-cy=repo-views-empty]", beVisible)
-)
+    ? newExpectation("", "[data-cy=repo-no-views]", beVisible)
+    : newExpectation("", "[data-cy=repo-views-empty]", beVisible);
 
 const notEmptyViewsExpectations = (
   viewsLen: number,
@@ -332,11 +331,10 @@ const testQueryClickFlow = (testQuery: string): ClickFlow =>
     ),
   ]);
 
-export const emptyQueriesExpectation = (hasBranch: boolean): Expectation => (
+export const emptyQueriesExpectation = (hasBranch: boolean): Expectation =>
   hasBranch
     ? newExpectation("", "[data-cy=repo-no-queries]", beVisible)
-    : newExpectation("", "[data-cy=repo-queries-empty]", beVisible)
-);
+    : newExpectation("", "[data-cy=repo-queries-empty]", beVisible);
 
 const notEmptyQueriesExpectations = (
   queryLen: number,
@@ -409,11 +407,10 @@ const testSchemaClickFlow = (testSchema: string): ClickFlow =>
     ),
   ]);
 
-export const emptySchemaExpectation = (hasBranch: boolean): Expectation => (  
+export const emptySchemaExpectation = (hasBranch: boolean): Expectation =>
   hasBranch
     ? newExpectation("", "[data-cy=repo-tables-empty]", beVisible)
-    : newExpectation("", "[data-cy=repo-schemas-empty]", beVisible))
-
+    : newExpectation("", "[data-cy=repo-schemas-empty]", beVisible);
 
 const notEmptySchemaExpectations = (
   schemaLen: number,

--- a/cypress/integration/utils/sharedTests/repoDatabaseNav.ts
+++ b/cypress/integration/utils/sharedTests/repoDatabaseNav.ts
@@ -120,7 +120,7 @@ export const conditionalEditButtonTest = (
 
 const testTablePlayClickFlow = (testTable: string): ClickFlow =>
   newClickFlow(
-    `[data-cy=repo-tables-table-${testTable}-play]`,
+    `[data-cy=repo-tables-table-${testTable}-play]` ,
     [
       newExpectation(
         "",
@@ -136,6 +136,26 @@ const testTablePlayClickFlow = (testTable: string): ClickFlow =>
     `[data-cy=repo-tables-table-${testTable}]`,
   );
 
+  export const conditionalPlayButtonTest = (
+    hasDocs: boolean,
+    testTable: string,
+  ) => {
+    const playExpectation: Expectation = hasDocs
+      ?   newExpectationWithClickFlows(
+        `should have test table ${testTable}`,
+        `[data-cy=repo-tables-table-${testTable}]`,
+        beVisible,
+        [testTablePlayClickFlow(testTable)],
+      )
+      : newExpectation(
+        "TESTING",
+        `[data-cy=repo-tables-table-viewing]`,
+        newShouldArgs("be.visible.and.contain", "Viewing"),
+      )
+  
+    return playExpectation;
+  };
+
 const emptyTablesExpectation = (hasBranch: boolean): Tests => [
   newExpectation(
     "should show empty tables message",
@@ -146,6 +166,7 @@ const emptyTablesExpectation = (hasBranch: boolean): Tests => [
 ];
 
 const notEmptyTableExpectations = (
+  hasDocs: boolean,
   hasBranch: boolean,
   loggedIn: boolean,
   tableLen: number,
@@ -156,12 +177,13 @@ const notEmptyTableExpectations = (
     "[data-cy=repo-tables-table-list] > ol > li",
     newShouldArgs("be.visible.and.have.length", tableLen),
   ),
-  newExpectationWithClickFlows(
-    `should have test table ${testTable}`,
-    `[data-cy=repo-tables-table-${testTable}]`,
-    beVisible,
-    [testTablePlayClickFlow(testTable)],
-  ),
+  // newExpectationWithClickFlows(
+  //   `should have test table ${testTable}`,
+  //   `[data-cy=repo-tables-table-${testTable}]`,
+  //   beVisible,
+  //   [testTablePlayClickFlow(testTable)],
+  // ),
+  conditionalPlayButtonTest(hasDocs, testTable),
   conditionalEditButtonTest(loggedIn, testTable),
   conditionalBranchTest(hasBranch),
   // WRITE MORE TABLE TESTS HERE
@@ -172,6 +194,7 @@ const notEmptyTableExpectations = (
 //* Use testTablesSection when table is not populated (left nav is initially closed)
 
 export const tableExpectations = (
+  hasDocs: boolean,
   hasBranch: boolean,
   loggedIn: boolean,
   tableLen: number,
@@ -180,7 +203,7 @@ export const tableExpectations = (
   const expectations =
     tableLen === 0 || !testTable
       ? emptyTablesExpectation(hasBranch)
-      : notEmptyTableExpectations(hasBranch, loggedIn, tableLen, testTable);
+      : notEmptyTableExpectations(hasDocs, hasBranch, loggedIn, tableLen, testTable);
 
   return [
     newExpectation(
@@ -193,6 +216,7 @@ export const tableExpectations = (
 };
 
 export const testTablesSection = (
+  hasDocs: boolean,
   hasBranch: boolean,
   loggedIn: boolean,
   tableLen: number,
@@ -213,7 +237,7 @@ export const testTablesSection = (
         checkSchemaClickflow,
       ],
     ),
-    ...tableExpectations(hasBranch, loggedIn, tableLen, testTable),
+    ...tableExpectations(hasDocs, hasBranch, loggedIn, tableLen, testTable),
   ];
 };
 
@@ -288,14 +312,22 @@ const testViewClickFlow = (testView: string): ClickFlow =>
     ),
     newExpectation(
       "",
-      "[data-cy=repo-table-header-query]",
+      "[data-cy=sql-editor-collapsed]",
       newShouldArgs("be.visible.and.contain", `SELECT * FROM ${testView}`),
     ),
   ]);
 
-const emptyViewsExpectation = [
-  newExpectation("", "[data-cy=repo-no-views]", beVisible),
-];
+// const emptyViewsExpectation = [
+//   newExpectation("", "[data-cy=repo-no-views]", beVisible),
+// ];
+
+export const emptyViewsExpectation = (hasBranch: boolean) => {
+  const viewsExpectation: Expectation = hasBranch
+    ? newExpectation("", "[data-cy=repo-no-views]", beVisible)
+    : newExpectation("", "[data-cy=repo-views-empty]", beVisible);
+
+  return viewsExpectation;
+};
 
 const notEmptyViewsExpectations = (
   viewsLen: number,
@@ -314,20 +346,21 @@ const notEmptyViewsExpectations = (
   ),
 ];
 
-const viewsClickFlow = (viewsLen: number, testView?: string): ClickFlow => {
+const viewsClickFlow = (
+  hasBranch: boolean,
+  viewsLen: number,
+  testView?: string,
+): ClickFlow => {
   const expectations =
     viewsLen === 0 || !testView
-      ? emptyViewsExpectation
+      ? [emptyViewsExpectation(hasBranch)]
       : notEmptyViewsExpectations(viewsLen, testView);
 
-  return newClickFlow(
-    "[data-cy=repo-views]",
-    expectations,
-    "[data-cy=repo-views]",
-  );
+  return newClickFlow("[data-cy=tab-views]", expectations);
 };
 
 export const testViewsSection = (
+  hasBranch: boolean,
   viewsLen: number,
   testView?: string,
 ): Expectation => {
@@ -336,11 +369,13 @@ export const testViewsSection = (
   }
   return newExpectationWithClickFlows(
     "should have repo Views section",
-    "[data-cy=repo-views]",
+    "[data-cy=tab-views]",
     beVisible,
-    [viewsClickFlow(viewsLen, testView)],
+    [viewsClickFlow(hasBranch, viewsLen, testView)],
   );
 };
+
+// newClickFlow("[data-cy=tab-views]",[])
 
 // QUERY CATALOG
 
@@ -418,3 +453,4 @@ export const testQueryCatalogSection = (
 };
 
 // KATIE WRITE SCHEMAS TESTS, ALL
+

--- a/cypress/integration/utils/sharedTests/repoDatabaseNav.ts
+++ b/cypress/integration/utils/sharedTests/repoDatabaseNav.ts
@@ -78,7 +78,7 @@ export const conditionalBranchTest = (hasBranch: boolean) => {
         "Should have an Add New Table button",
         "[data-cy=repo-tables-add-table]",
         beVisible,
-        true
+        true,
       )
     : newExpectation(
         "Should not have an Add New Table button",
@@ -119,19 +119,21 @@ export const conditionalEditButtonTest = (
 };
 
 const testTablePlayClickFlow = (testTable: string): ClickFlow =>
-  newClickFlow(`[data-cy=repo-tables-table-${testTable}-play]`, [
-    newExpectation(
-      "",
-      `[data-cy=repo-tables-table-${testTable}-column-list]`,
-      beVisible,
-    ),
-    newExpectation(
-      "",
-      `[data-cy=repo-tables-table-viewing]`,
-      newShouldArgs("be.visible.and.contain", "Viewing"),
-    ),   
-  ],
-  `[data-cy=repo-tables-table-${testTable}]`
+  newClickFlow(
+    `[data-cy=repo-tables-table-${testTable}-play]`,
+    [
+      newExpectation(
+        "",
+        `[data-cy=repo-tables-table-${testTable}-column-list]`,
+        beVisible,
+      ),
+      newExpectation(
+        "",
+        `[data-cy=repo-tables-table-viewing]`,
+        newShouldArgs("be.visible.and.contain", "Viewing"),
+      ),
+    ],
+    `[data-cy=repo-tables-table-${testTable}]`,
   );
 
 const emptyTablesExpectation = (hasBranch: boolean): Tests => [

--- a/cypress/integration/utils/sharedTests/repoDatabaseNav.ts
+++ b/cypress/integration/utils/sharedTests/repoDatabaseNav.ts
@@ -72,6 +72,22 @@ export const checkSchemaClickflow: ClickFlow = newClickFlow(
 
 // TABLES
 
+export const conditionalBranchTest = (hasBranch: boolean) => {
+  const branchExpectation: Expectation = hasBranch
+    ? newExpectation(
+        "Should have an Add New Table button",
+        "[data-cy=repo-tables-add-table]",
+        beVisible
+      )
+    : newExpectation(
+        "Should not have an Add New Table button",
+        "[data-cy=repo-tables-add-table]",
+        newShouldArgs("not.exist"),
+      );
+
+  return branchExpectation;
+};
+
 const testTablePlayClickFlow = (testTable: string): ClickFlow =>
   newClickFlow(`[data-cy=repo-tables-table-${testTable}-play]`, [
     newExpectation(
@@ -84,6 +100,7 @@ const testTablePlayClickFlow = (testTable: string): ClickFlow =>
       `[data-cy=repo-tables-table-viewing]`,
       newShouldArgs("be.visible.and.contain", "Viewing"),
     ),
+
   ]);
 
   // const testTableEditClickFlow = (testTable: string): ClickFlow =>
@@ -95,17 +112,21 @@ const testTablePlayClickFlow = (testTable: string): ClickFlow =>
   //   ),
   // ]);
 
-const emptyTablesExpectation = [
+const emptyTablesExpectation = (
+  hasBranch: boolean
+): Tests => [
   newExpectation(
     "should show empty tables message",
     "[data-cy=repo-tables-empty]",
     beVisible,
   ),
+  conditionalBranchTest(hasBranch)
 ];
 
 const notEmptyTableExpectations = (
   tableLen: number,
   testTable: string,
+  hasBranch: boolean,
 ): Tests => [
   newExpectation(
     `should have table list with ${tableLen} items`,
@@ -118,6 +139,7 @@ const notEmptyTableExpectations = (
     beVisible,
     [testTablePlayClickFlow(testTable), ],
   ),
+  conditionalBranchTest(hasBranch)
   // WRITE MORE TABLE TESTS HERE
   //
 ];
@@ -126,13 +148,14 @@ const notEmptyTableExpectations = (
 //* Use testTablesSection when table is not populated (left nav is initially closed)
 
 export const tableExpectations = (
+  hasBranch: boolean,
   tableLen: number,
   testTable?: string,
 ): Expectation[] => {
   const expectations =
     tableLen === 0 || !testTable
-      ? emptyTablesExpectation
-      : notEmptyTableExpectations(tableLen, testTable);
+      ? emptyTablesExpectation(hasBranch)
+      : notEmptyTableExpectations(tableLen, testTable, hasBranch);
 
   return [
     newExpectation(
@@ -145,6 +168,7 @@ export const tableExpectations = (
 };
 
 export const testTablesSection = (
+  hasBranch: boolean,
   tableLen: number,
   testTable?: string,
 ): Expectation[] => {
@@ -163,7 +187,7 @@ export const testTablesSection = (
         checkSchemaClickflow,
       ],
     ),
-    ...tableExpectations(tableLen, testTable),
+    ...tableExpectations(hasBranch, tableLen, testTable),
   ];
 };
 

--- a/cypress/integration/utils/sharedTests/repoDatabaseNav.ts
+++ b/cypress/integration/utils/sharedTests/repoDatabaseNav.ts
@@ -83,7 +83,7 @@ export const conditionalBranchTest = (hasBranch: boolean) => {
     : newExpectation(
         "Should not have an Add New Table button",
         "[data-cy=repo-tables-add-table]",
-        newShouldArgs("not.exist"),
+        notExist,
       );
 
   return branchExpectation;
@@ -112,7 +112,7 @@ export const conditionalEditButtonTest = (
     : newExpectation(
         "Should not have an Edit button",
         `[data-cy=repo-tables-table-${testTable}-edit]`,
-        newShouldArgs("not.exist"),
+        notExist,
       );
 
   return editExpectation;
@@ -399,10 +399,18 @@ const testQueryClickFlow = (testQuery: string): ClickFlow =>
     ),
   ]);
 
-const emptyQueriesExpectation = [
-  newExpectation("", "[data-cy=repo-no-queries]", beVisible),
-  newExpectation("", "[data-cy=repo-query-see-all]", notExist),
-];
+// const emptyQueriesExpectation = [
+//   newExpectation("", "[data-cy=repo-no-queries]", beVisible),
+//   newExpectation("", "[data-cy=repo-query-see-all]", notExist),
+// ];
+
+export const emptyQueriesExpectation = (hasBranch: boolean) => {
+  const queriesExpectation: Expectation = hasBranch
+    ? newExpectation("", "[data-cy=repo-no-queries]", beVisible)
+    : newExpectation("", "[data-cy=repo-queries-empty]", beVisible);
+
+  return queriesExpectation;
+};
 
 const notEmptyQueriesExpectations = (
   queryLen: number,
@@ -428,22 +436,23 @@ const notEmptyQueriesExpectations = (
 ];
 
 const queryCatalogClickFlow = (
+  hasBranch: boolean,
   queryLen: number,
   testQuery?: string,
 ): ClickFlow => {
   const expectations =
     queryLen === 0 || !testQuery
-      ? emptyQueriesExpectation
+      ? [emptyQueriesExpectation(hasBranch)]
       : notEmptyQueriesExpectations(queryLen, testQuery);
 
   return newClickFlow(
-    "[data-cy=repo-query-catalog]",
+    "[data-cy=tab-queries]",
     expectations,
-    "[data-cy=repo-query-catalog]",
   );
 };
 
 export const testQueryCatalogSection = (
+  hasBranch: boolean,
   queryLen: number,
   testQuery?: string,
 ): Expectation => {
@@ -452,9 +461,9 @@ export const testQueryCatalogSection = (
   }
   return newExpectationWithClickFlows(
     "should have repo Query Catalog section",
-    "[data-cy=repo-query-catalog]",
+    "[data-cy=tab-queries]",
     beVisible,
-    [queryCatalogClickFlow(queryLen, testQuery)],
+    [queryCatalogClickFlow(hasBranch,queryLen, testQuery)],
   );
 };
 

--- a/cypress/integration/utils/sharedTests/repoDatabaseNav.ts
+++ b/cypress/integration/utils/sharedTests/repoDatabaseNav.ts
@@ -186,12 +186,6 @@ const notEmptyTableExpectations = (
     "[data-cy=repo-tables-table-list] > ol > li",
     newShouldArgs("be.visible.and.have.length", tableLen),
   ),
-  // newExpectationWithClickFlows(
-  //   `should have test table ${testTable}`,
-  //   `[data-cy=repo-tables-table-${testTable}]`,
-  //   beVisible,
-  //   [testTablePlayClickFlow(testTable)],
-  // ),
   ...conditionalPlayButtonTest(hasDocs, testTable),
   conditionalEditButtonTest(loggedIn, testTable),
   conditionalBranchTest(hasBranch),
@@ -456,7 +450,7 @@ const schemaClickFlow = (
       ? [emptySchemaExpectation(hasBranch)]
       : notEmptySchemaExpectations(schemaLen, testSchema);
 
-  return newClickFlow("[data-cy=tab-schemas]", expectations);
+  return newClickFlow("[data-cy=tab-schemas]", expectations, "[data-cy=tab-tables]");
 };
 
 export const testSchemaSection = (

--- a/cypress/integration/utils/sharedTests/repoDatabaseNav.ts
+++ b/cypress/integration/utils/sharedTests/repoDatabaseNav.ts
@@ -332,7 +332,7 @@ const testQueryClickFlow = (testQuery: string): ClickFlow =>
     ),
   ]);
 
-export const emptyQueriesExpectation = (hasBranch: boolean): Expection => (
+export const emptyQueriesExpectation = (hasBranch: boolean): Expectation => (
   hasBranch
     ? newExpectation("", "[data-cy=repo-no-queries]", beVisible)
     : newExpectation("", "[data-cy=repo-queries-empty]", beVisible)

--- a/cypress/integration/utils/sharedTests/repoDatabaseNav.ts
+++ b/cypress/integration/utils/sharedTests/repoDatabaseNav.ts
@@ -394,15 +394,10 @@ const testQueryClickFlow = (testQuery: string): ClickFlow =>
     ),
     newExpectation(
       "",
-      "[data-cy=repo-table-header-query] div > span",
-      newShouldArgs("be.visible.and.contain", testQuery),
+      "[data-cy=sql-editor-collapsed]",
+      newShouldArgs("be.visible.and.contain", `select * from ${testQuery}`),
     ),
   ]);
-
-// const emptyQueriesExpectation = [
-//   newExpectation("", "[data-cy=repo-no-queries]", beVisible),
-//   newExpectation("", "[data-cy=repo-query-see-all]", notExist),
-// ];
 
 export const emptyQueriesExpectation = (hasBranch: boolean) => {
   const queriesExpectation: Expectation = hasBranch
@@ -428,7 +423,7 @@ const notEmptyQueriesExpectations = (
     newShouldArgs("be.visible.and.have.length", queryLen),
   ),
   newExpectationWithClickFlows(
-    "should successfully execute a view",
+    "should successfully execute a query",
     `[data-cy=repo-query-list-query-${testQuery}]`,
     beVisible,
     [testQueryClickFlow(testQuery)],

--- a/cypress/integration/utils/sharedTests/repoDatabaseNav.ts
+++ b/cypress/integration/utils/sharedTests/repoDatabaseNav.ts
@@ -414,7 +414,10 @@ const testSchemaClickFlow = (testSchema: string): ClickFlow =>
     newExpectation(
       "",
       "[data-cy=sql-editor-collapsed]",
-      newShouldArgs("be.visible.and.contain", `SHOW CREATE TABLE ${testSchema}`),
+      newShouldArgs(
+        "be.visible.and.contain",
+        `SHOW CREATE TABLE ${testSchema}`,
+      ),
     ),
   ]);
 

--- a/cypress/integration/utils/sharedTests/repoDatabaseNav.ts
+++ b/cypress/integration/utils/sharedTests/repoDatabaseNav.ts
@@ -120,7 +120,7 @@ export const conditionalEditButtonTest = (
 
 const testTablePlayClickFlow = (testTable: string): ClickFlow =>
   newClickFlow(
-    `[data-cy=repo-tables-table-${testTable}-play]` ,
+    `[data-cy=repo-tables-table-${testTable}-play]`,
     [
       newExpectation(
         "",
@@ -136,25 +136,25 @@ const testTablePlayClickFlow = (testTable: string): ClickFlow =>
     `[data-cy=repo-tables-table-${testTable}]`,
   );
 
-  export const conditionalPlayButtonTest = (
-    hasDocs: boolean,
-    testTable: string,
-  ) => {
-    const playExpectation: Expectation = hasDocs
-      ?   newExpectationWithClickFlows(
+export const conditionalPlayButtonTest = (
+  hasDocs: boolean,
+  testTable: string,
+) => {
+  const playExpectation: Expectation = hasDocs
+    ? newExpectationWithClickFlows(
         `should have test table ${testTable}`,
         `[data-cy=repo-tables-table-${testTable}]`,
         beVisible,
         [testTablePlayClickFlow(testTable)],
       )
-      : newExpectation(
+    : newExpectation(
         "TESTING",
         `[data-cy=repo-tables-table-viewing]`,
         newShouldArgs("be.visible.and.contain", "Viewing"),
-      )
-  
-    return playExpectation;
-  };
+      );
+
+  return playExpectation;
+};
 
 const emptyTablesExpectation = (hasBranch: boolean): Tests => [
   newExpectation(
@@ -203,7 +203,13 @@ export const tableExpectations = (
   const expectations =
     tableLen === 0 || !testTable
       ? emptyTablesExpectation(hasBranch)
-      : notEmptyTableExpectations(hasDocs, hasBranch, loggedIn, tableLen, testTable);
+      : notEmptyTableExpectations(
+          hasDocs,
+          hasBranch,
+          loggedIn,
+          tableLen,
+          testTable,
+        );
 
   return [
     newExpectation(
@@ -453,4 +459,3 @@ export const testQueryCatalogSection = (
 };
 
 // KATIE WRITE SCHEMAS TESTS, ALL
-

--- a/cypress/integration/utils/sharedTests/repoDatabaseNav.ts
+++ b/cypress/integration/utils/sharedTests/repoDatabaseNav.ts
@@ -72,7 +72,7 @@ export const checkSchemaClickflow: ClickFlow = newClickFlow(
 
 // TABLES
 
-const testTableClickFlow = (testTable: string): ClickFlow =>
+const testTablePlayClickFlow = (testTable: string): ClickFlow =>
   newClickFlow(`[data-cy=repo-tables-table-${testTable}-play]`, [
     newExpectation(
       "",
@@ -102,9 +102,14 @@ const notEmptyTableExpectations = (
     `should have test table ${testTable}`,
     `[data-cy=repo-tables-table-${testTable}]`,
     beVisible,
-    [testTableClickFlow(testTable)],
+    [testTablePlayClickFlow(testTable)],
   ),
+  // WRITE MORE TABLE TESTS HERE
+  //
 ];
+
+//* Use tableExpectations when table is populated (left nav is initially open)
+//* Use testTablesSection when table is not populated (left nav is initially closed)
 
 export const tableExpectations = (
   tableLen: number,
@@ -149,64 +154,64 @@ export const testTablesSection = (
 };
 
 // INDEXES
+//! No longer on the site
+// const testIndexClickFlow = (testTable: string): ClickFlow =>
+//   newClickFlow(`[data-cy=repo-indexes-table-${testTable}]`, [
+//     newExpectation(
+//       "",
+//       `[data-cy=repo-indexes-table-${testTable}-no-indexes]`,
+//       beVisible,
+//     ),
+//   ]);
 
-const testIndexClickFlow = (testTable: string): ClickFlow =>
-  newClickFlow(`[data-cy=repo-indexes-table-${testTable}]`, [
-    newExpectation(
-      "",
-      `[data-cy=repo-indexes-table-${testTable}-no-indexes]`,
-      beVisible,
-    ),
-  ]);
+// const emptyIndexesExpectation = [
+//   newExpectation("", "[data-cy=repo-indexes-empty]", beVisible),
+// ];
 
-const emptyIndexesExpectation = [
-  newExpectation("", "[data-cy=repo-indexes-empty]", beVisible),
-];
+// const notEmptyIndexesExpectations = (
+//   indexLen: number,
+//   testTable: string,
+// ): Tests => [
+//   newExpectation(
+//     "",
+//     "[data-cy=repo-indexes-table-list] > li",
+//     newShouldArgs("be.visible.and.have.length", indexLen),
+//   ),
+//   newExpectationWithClickFlows(
+//     "",
+//     `[data-cy=repo-indexes-table-${testTable}]`,
+//     beVisible,
+//     [testIndexClickFlow(testTable)],
+//   ),
+// ];
 
-const notEmptyIndexesExpectations = (
-  indexLen: number,
-  testTable: string,
-): Tests => [
-  newExpectation(
-    "",
-    "[data-cy=repo-indexes-table-list] > li",
-    newShouldArgs("be.visible.and.have.length", indexLen),
-  ),
-  newExpectationWithClickFlows(
-    "",
-    `[data-cy=repo-indexes-table-${testTable}]`,
-    beVisible,
-    [testIndexClickFlow(testTable)],
-  ),
-];
+// const indexesClickFlow = (indexLen: number, testTable?: string): ClickFlow => {
+//   const expectations =
+//     indexLen === 0 || !testTable
+//       ? emptyIndexesExpectation
+//       : notEmptyIndexesExpectations(indexLen, testTable);
 
-const indexesClickFlow = (indexLen: number, testTable?: string): ClickFlow => {
-  const expectations =
-    indexLen === 0 || !testTable
-      ? emptyIndexesExpectation
-      : notEmptyIndexesExpectations(indexLen, testTable);
+//   return newClickFlow(
+//     "[data-cy=repo-indexes]",
+//     expectations,
+//     "[data-cy=repo-indexes]",
+//   );
+// };
 
-  return newClickFlow(
-    "[data-cy=repo-indexes]",
-    expectations,
-    "[data-cy=repo-indexes]",
-  );
-};
-
-export const testIndexesSection = (
-  indexLen: number,
-  testTable?: string,
-): Expectation => {
-  if (indexLen > 0 && !testTable) {
-    throw new Error("Cannot have indexLen > 0 and no testTable");
-  }
-  return newExpectationWithClickFlows(
-    "should have repo Indexes section",
-    "[data-cy=repo-indexes]",
-    beVisible,
-    [indexesClickFlow(indexLen, testTable)],
-  );
-};
+// export const testIndexesSection = (
+//   indexLen: number,
+//   testTable?: string,
+// ): Expectation => {
+//   if (indexLen > 0 && !testTable) {
+//     throw new Error("Cannot have indexLen > 0 and no testTable");
+//   }
+//   return newExpectationWithClickFlows(
+//     "should have repo Indexes section",
+//     "[data-cy=repo-indexes]",
+//     beVisible,
+//     [indexesClickFlow(indexLen, testTable)],
+//   );
+// };
 
 // VIEWS
 

--- a/cypress/integration/utils/sharedTests/repoDatabaseNav.ts
+++ b/cypress/integration/utils/sharedTests/repoDatabaseNav.ts
@@ -256,66 +256,6 @@ export const testTablesSection = (
   ];
 };
 
-// INDEXES
-//! No longer on the site
-// const testIndexClickFlow = (testTable: string): ClickFlow =>
-//   newClickFlow(`[data-cy=repo-indexes-table-${testTable}]`, [
-//     newExpectation(
-//       "",
-//       `[data-cy=repo-indexes-table-${testTable}-no-indexes]`,
-//       beVisible,
-//     ),
-//   ]);
-
-// const emptyIndexesExpectation = [
-//   newExpectation("", "[data-cy=repo-indexes-empty]", beVisible),
-// ];
-
-// const notEmptyIndexesExpectations = (
-//   indexLen: number,
-//   testTable: string,
-// ): Tests => [
-//   newExpectation(
-//     "",
-//     "[data-cy=repo-indexes-table-list] > li",
-//     newShouldArgs("be.visible.and.have.length", indexLen),
-//   ),
-//   newExpectationWithClickFlows(
-//     "",
-//     `[data-cy=repo-indexes-table-${testTable}]`,
-//     beVisible,
-//     [testIndexClickFlow(testTable)],
-//   ),
-// ];
-
-// const indexesClickFlow = (indexLen: number, testTable?: string): ClickFlow => {
-//   const expectations =
-//     indexLen === 0 || !testTable
-//       ? emptyIndexesExpectation
-//       : notEmptyIndexesExpectations(indexLen, testTable);
-
-//   return newClickFlow(
-//     "[data-cy=repo-indexes]",
-//     expectations,
-//     "[data-cy=repo-indexes]",
-//   );
-// };
-
-// export const testIndexesSection = (
-//   indexLen: number,
-//   testTable?: string,
-// ): Expectation => {
-//   if (indexLen > 0 && !testTable) {
-//     throw new Error("Cannot have indexLen > 0 and no testTable");
-//   }
-//   return newExpectationWithClickFlows(
-//     "should have repo Indexes section",
-//     "[data-cy=repo-indexes]",
-//     beVisible,
-//     [indexesClickFlow(indexLen, testTable)],
-//   );
-// };
-
 // VIEWS
 
 const testViewClickFlow = (testView: string): ClickFlow =>
@@ -462,4 +402,72 @@ export const testQueryCatalogSection = (
   );
 };
 
-// KATIE WRITE SCHEMAS TESTS, ALL
+// SCHEMAS
+
+const testSchemaClickFlow = (testSchema: string): ClickFlow =>
+  newClickFlow(`[data-cy=repo-schema-button-${testSchema}]`, [
+    newExpectation(
+      "",
+      `[data-cy=repo-schema-viewing-${testSchema}]`,
+      newShouldArgs("be.visible.and.contain", "Viewing"),
+    ),
+    newExpectation(
+      "",
+      "[data-cy=sql-editor-collapsed]",
+      newShouldArgs("be.visible.and.contain", `SHOW CREATE TABLE ${testSchema}`),
+    ),
+  ]);
+
+export const emptySchemaExpectation = (hasBranch: boolean) => {
+  const schemaExpectation: Expectation = hasBranch
+    ? newExpectation("", "[data-cy=repo-no-schemas]", beVisible)
+    : newExpectation("", "[data-cy=repo-schemas-empty]", beVisible);
+
+  return schemaExpectation;
+};
+
+const notEmptySchemaExpectations = (
+  schemaLen: number,
+  testSchema: string,
+): Tests => [
+  newExpectation(
+    "",
+    "[data-cy=repo-tables-schema-list] > ol > li",
+    newShouldArgs("be.visible.and.have.length", schemaLen),
+  ),
+  newExpectationWithClickFlows(
+    "should successfully execute a schema",
+    `[data-cy=repo-schema-list-schema-${testSchema}]`,
+    beVisible,
+    [testSchemaClickFlow(testSchema)],
+  ),
+];
+
+const schemaClickFlow = (
+  hasBranch: boolean,
+  schemaLen: number,
+  testSchema?: string,
+): ClickFlow => {
+  const expectations =
+    schemaLen === 0 || !testSchema
+      ? [emptySchemaExpectation(hasBranch)]
+      : notEmptySchemaExpectations(schemaLen, testSchema);
+
+  return newClickFlow("[data-cy=tab-schemas]", expectations);
+};
+
+export const testSchemaSection = (
+  hasBranch: boolean,
+  schemaLen: number,
+  testSchema?: string,
+): Expectation => {
+  if (schemaLen > 0 && !testSchema) {
+    throw new Error("Cannot have schemaLen > 0 and no testSchema");
+  }
+  return newExpectationWithClickFlows(
+    "should have repo Schema section",
+    "[data-cy=tab-schemas]",
+    beVisible,
+    [schemaClickFlow(hasBranch, schemaLen, testSchema)],
+  );
+};

--- a/cypress/integration/utils/sharedTests/repoDatabaseNav.ts
+++ b/cypress/integration/utils/sharedTests/repoDatabaseNav.ts
@@ -123,12 +123,12 @@ const testTablePlayClickFlow = (testTable: string): ClickFlow =>
     `[data-cy=repo-tables-table-${testTable}-play]`,
     [
       newExpectation(
-        "",
+        "Should show a list of columns",
         `[data-cy=repo-tables-table-${testTable}-column-list]`,
         beVisible,
       ),
       newExpectation(
-        "",
+        "Should show 'viewing'",
         `[data-cy=repo-tables-table-viewing]`,
         newShouldArgs("be.visible.and.contain", "Viewing"),
       ),
@@ -140,18 +140,24 @@ export const conditionalPlayButtonTest = (
   hasDocs: boolean,
   testTable: string,
 ) => {
-  const playExpectation: Expectation = hasDocs
-    ? newExpectationWithClickFlows(
+  const playExpectation: Tests = hasDocs
+    ? [newExpectationWithClickFlows(
         `should have test table ${testTable}`,
         `[data-cy=repo-tables-table-${testTable}]`,
         beVisible,
         [testTablePlayClickFlow(testTable)],
-      )
-    : newExpectation(
-        "TESTING",
+      )]
+    : [newExpectation(
+        "Should show a list of columns",
+        `[data-cy=repo-tables-table-${testTable}-column-list]`,
+        beVisible,
+      ),
+      newExpectation(
+        "Should show 'viewing'",
         `[data-cy=repo-tables-table-viewing]`,
         newShouldArgs("be.visible.and.contain", "Viewing"),
-      );
+      ),
+    ]
 
   return playExpectation;
 };
@@ -183,7 +189,7 @@ const notEmptyTableExpectations = (
   //   beVisible,
   //   [testTablePlayClickFlow(testTable)],
   // ),
-  conditionalPlayButtonTest(hasDocs, testTable),
+  ...conditionalPlayButtonTest(hasDocs, testTable),
   conditionalEditButtonTest(loggedIn, testTable),
   conditionalBranchTest(hasBranch),
   // WRITE MORE TABLE TESTS HERE
@@ -323,10 +329,6 @@ const testViewClickFlow = (testView: string): ClickFlow =>
     ),
   ]);
 
-// const emptyViewsExpectation = [
-//   newExpectation("", "[data-cy=repo-no-views]", beVisible),
-// ];
-
 export const emptyViewsExpectation = (hasBranch: boolean) => {
   const viewsExpectation: Expectation = hasBranch
     ? newExpectation("", "[data-cy=repo-no-views]", beVisible)
@@ -380,8 +382,6 @@ export const testViewsSection = (
     [viewsClickFlow(hasBranch, viewsLen, testView)],
   );
 };
-
-// newClickFlow("[data-cy=tab-views]",[])
 
 // QUERY CATALOG
 

--- a/cypress/integration/utils/sharedTests/repoLeftNav.ts
+++ b/cypress/integration/utils/sharedTests/repoLeftNav.ts
@@ -34,7 +34,10 @@ export const testAboutSection = (initiallyOpen: boolean): Expectation =>
 
 // TABLES
 
-const testTablePlayClickFlow = (tableLen: number, testTable: string): ClickFlow =>
+const testTablePlayClickFlow = (
+  tableLen: number,
+  testTable: string,
+): ClickFlow =>
   newClickFlow(
     `[data-cy=repo-tables-table-${testTable}${tableLen === 1 ? "" : "-play"}]`,
     [

--- a/cypress/integration/utils/sharedTests/repoLeftNav.ts
+++ b/cypress/integration/utils/sharedTests/repoLeftNav.ts
@@ -34,7 +34,7 @@ export const testAboutSection = (initiallyOpen: boolean): Expectation =>
 
 // TABLES
 
-const testTableClickFlow = (tableLen: number, testTable: string): ClickFlow =>
+const testTablePlayClickFlow = (tableLen: number, testTable: string): ClickFlow =>
   newClickFlow(
     `[data-cy=repo-tables-table-${testTable}${tableLen === 1 ? "" : "-play"}]`,
     [
@@ -63,7 +63,7 @@ const notEmptyTableExpectations = (
     "",
     `[data-cy=repo-tables-table-${testTable}]`,
     beVisible,
-    [testTableClickFlow(tableLen, testTable)],
+    [testTablePlayClickFlow(tableLen, testTable)],
   ),
 ];
 

--- a/cypress/integration/utils/sharedTests/repoLeftNav.ts
+++ b/cypress/integration/utils/sharedTests/repoLeftNav.ts
@@ -327,9 +327,9 @@ const queryCatalogClickFlow = (
       : notEmptyQueriesExpectations(queryLen, testQuery);
 
   return newClickFlow(
-    "[data-cy=repo-query-catalog]",
+    "[data-cy=tab-queries]",
     expectations,
-    "[data-cy=repo-query-catalog]",
+    "[data-cy=tab-queries]",
   );
 };
 
@@ -342,7 +342,7 @@ export const testQueryCatalogSection = (
   }
   return newExpectationWithClickFlows(
     "should have repo Query Catalog section",
-    "[data-cy=repo-query-catalog]",
+    "[data-cy=tab-queries]",
     beVisible,
     [queryCatalogClickFlow(queryLen, testQuery)],
   );


### PR DESCRIPTION
Changed files: 
privatePaths/render/database/
  - empty
  - emptyWithBranch
  - tablesAndDocs

publicPaths/render/database/ 
  - corona-virus
  - docsNoTables
  - empty
  - emptyWithBranch
  - forked
  - ngrams
  - tablesAndDocs
  - tablesNoDocs
  - tags
utils/sharedTests/repoDatabaseNav

On all files above...
- Circulated through all tab to make sure the the "active" tag worked as anticipated  
- Tested the tables tab by
    * if no tables, 
      * checked for no tables message. 
    * If tables, 
      * made sure there were the right amount
      * that it had the right amount of columns
      * tested the play button, and that it rendered viewing when viewing
      * If not logged in, no edit table button
      * If logged in checked for edit table button
      * that it had an add table button
 - Tested the Views tab by
    * if no views, 
      * checked for no views (with branch vs no branch)
    * If views, 
      * checked that list was present and the correct length
      *  tested the play button, and that it rendered viewing when viewing
      * checked sql query was accurate
 - Tested the Queries tab by
    * if no queries, 
      * checked for no queries (with branch vs no branch)
    * If queries, 
      * checked that list was present and the correct length
      *  tested the play button, and that it rendered viewing when viewing
      * checked sql query was accurate
 - Tested the Schema tab by
    * if no schemas, 
      * checked for no schema (with branch vs no branch)
    * If schemas, 
      * checked that list was present and the correct length
      *  tested the play button, and that it rendered viewing when viewing
      * checked sql query was accurate