### PR TITLE
Tag katie in dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,7 @@ updates:
     timezone: America/Los_Angeles
   open-pull-requests-limit: 10
   reviewers:
-  - tbantle22
+  - cheshirekate8
   labels:
   - dependencies
   ignore:


### PR DESCRIPTION
I'm giving you ownership over dependency bumps for this repo. Essentially, on the first of every month [dependabot](https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/about-dependabot-version-updates) will bump the version of any package in the `package.json` that needs an upgrade and tag you in a pull request with the change. 

Your job is to make sure the bumps don't break anything. It's pretty easy for this repo because if CI passes there's a 99% chance you're good to go. Sometimes CI will break and you'll either need to fix something or decide to close the dependency bump PR. 

You won't have to worry about this until Dec 1 but just wanted to give you the heads up!