### PR TITLE
Add husky

### DIFF
--- a/.husky/post-checkout
+++ b/.husky/post-checkout
@@ -1,0 +1,8 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+if [ -d "./node_modules/yarnhook" ]; then
+   yarn yarnhook
+else
+   yarn install
+fi

--- a/.husky/post-merge
+++ b/.husky/post-merge
@@ -1,0 +1,8 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+if [ -d "./node_modules/yarnhook" ]; then
+   yarn yarnhook
+else
+   yarn install
+fi

--- a/.husky/post-rewrite
+++ b/.husky/post-rewrite
@@ -1,0 +1,8 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+if [ -d "./node_modules/yarnhook" ]; then
+   yarn yarnhook
+else
+   yarn install
+fi

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "compile": "tsc -b",
     "lint": "eslint --cache --ext .ts,.js .",
     "prettier": "prettier --check 'cypress/**/*.{ts,js}'",
-    "prettier:fix": "prettier --write 'cypress/**/*.{ts,js}'"
+    "prettier:fix": "prettier --write 'cypress/**/*.{ts,js}'",
+    "postinstall": "bash -c 'if [ -z \"$HUSKY_SKIP_INSTALL\" ]; then husky install .husky; fi'"
   },
   "devDependencies": {
     "@babel/cli": "^7.17.0",
@@ -38,8 +39,10 @@
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-cypress": "^2.12.1",
     "eslint-plugin-import": "^2.25.4",
+    "husky": "^7.0.4",
     "npm-run-all": "^4.1.5",
-    "prettier": "^2.5.1"
+    "prettier": "^2.5.1",
+    "yarnhook": "^0.5.1"
   },
   "dependencies": {
     "cypress": "9.4.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3117,9 +3117,11 @@ __metadata:
     eslint-config-prettier: ^8.3.0
     eslint-plugin-cypress: ^2.12.1
     eslint-plugin-import: ^2.25.4
+    husky: ^7.0.4
     npm-run-all: ^4.1.5
     prettier: ^2.5.1
     typescript: ^4.5.5
+    yarnhook: ^0.5.1
   languageName: unknown
   linkType: soft
 
@@ -3587,7 +3589,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"execa@npm:4.1.0":
+"execa@npm:4.1.0, execa@npm:^4.0.3":
   version: 4.1.0
   resolution: "execa@npm:4.1.0"
   dependencies:
@@ -3728,6 +3730,13 @@ __metadata:
   dependencies:
     to-regex-range: ^5.0.1
   checksum: cc283f4e65b504259e64fd969bcf4def4eb08d85565e906b7d36516e87819db52029a76b6363d0f02d0d532f0033c9603b9e2d943d56ee3b0d4f7ad3328ff917
+  languageName: node
+  linkType: hard
+
+"find-parent-dir@npm:^0.3.0":
+  version: 0.3.1
+  resolution: "find-parent-dir@npm:0.3.1"
+  checksum: 55e722584760cfbc6611901c7ced5081345cf629e2ecd6a4f6704b13b5a1876c8d9d9db5fd4965ba23e1ecbc24a8b62af40379cfef1ffa0231719b9d924eebdd
   languageName: node
   linkType: hard
 
@@ -4180,6 +4189,15 @@ __metadata:
   dependencies:
     ms: ^2.0.0
   checksum: 9c7a74a2827f9294c009266c82031030eae811ca87b0da3dceb8d6071b9bde22c9f3daef0469c3c533cc67a97d8a167cd9fc0389350e5f415f61a79b171ded16
+  languageName: node
+  linkType: hard
+
+"husky@npm:^7.0.4":
+  version: 7.0.4
+  resolution: "husky@npm:7.0.4"
+  bin:
+    husky: lib/bin.js
+  checksum: c6ec4af63da2c9522da8674a20ad9b48362cc92704896cc8a58c6a2a39d797feb2b806f93fbd83a6d653fbdceb2c3b6e0b602c6b2e8565206ffc2882ef7db9e9
   languageName: node
   linkType: hard
 
@@ -6675,6 +6693,18 @@ __metadata:
   version: 4.0.0
   resolution: "yallist@npm:4.0.0"
   checksum: 343617202af32df2a15a3be36a5a8c0c8545208f3d3dfbc6bb7c3e3b7e8c6f8e7485432e4f3b88da3031a6e20afa7c711eded32ddfb122896ac5d914e75848d5
+  languageName: node
+  linkType: hard
+
+"yarnhook@npm:^0.5.1":
+  version: 0.5.1
+  resolution: "yarnhook@npm:0.5.1"
+  dependencies:
+    execa: ^4.0.3
+    find-parent-dir: ^0.3.0
+  bin:
+    yarnhook: index.js
+  checksum: 8af2420e392c13792a6c8a44688c830a27661d917954d87faacab732299e79bf0cdefb55d68affc2543bcb65b0404e96dacd5230c92dd838026c4eed26409fef
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This automatically updates node_modules when there are changes to yarn.lock so that you don't need to run `yarn install` every time we update a dependency