### PR TITLE
organization repo number changed

### DIFF
--- a/cypress/integration/dolthub/productionTests/publicPaths/render/organizations/index.spec.ts
+++ b/cypress/integration/dolthub/productionTests/publicPaths/render/organizations/index.spec.ts
@@ -126,7 +126,7 @@ describe(`${pageName} renders expected components on different devices`, () => {
     newExpectation(
       "should show list of owner repositories",
       "[data-cy=repository-list-for-owner] li",
-      newShouldArgs("be.visible.and.have.length.of.at.least", 10),
+      newShouldArgs("be.visible.and.have.length.of.at.least", 9),
       skip,
     ),
     newExpectation(


### PR DESCRIPTION
it seems that the number of repos on this [page](https://www.dolthub.com/organizations/dolthub)  has changed from 10 to 9, causing the test to fail.