### PR TITLE
Liuliu/data table test fix

### DIFF
--- a/cypress/integration/dolthub/productionTests/publicPaths/render/database/corona-virus.spec.ts
+++ b/cypress/integration/dolthub/productionTests/publicPaths/render/database/corona-virus.spec.ts
@@ -5,12 +5,15 @@ import {
   macbook15ForAppLayout,
 } from "../../../../../utils/devices";
 import {
-  newExpectation,
-  newShouldArgs,
   newClickFlow,
+  newExpectation,
   newExpectationWithClickFlows,
+  newShouldArgs,
 } from "../../../../../utils/helpers";
-import { testRepoHeaderWithBranch } from "../../../../../utils/sharedTests/repoHeaderNav";
+import {
+  testMobileRepoHeaderNav,
+  testRepoHeaderWithBranch,
+} from "../../../../../utils/sharedTests/repoHeaderNav";
 import {
   tableExpectations,
   testClickDeleteRow,
@@ -18,10 +21,9 @@ import {
   testSchemaSection,
   testViewsSection,
 } from "../../../../../utils/sharedTests/repoLeftNav";
-import { testSqlConsole } from "../../../../../utils/sharedTests/sqlEditor";
-import { mobileTests } from "../../../../../utils/sharedTests/testRepoPageMobile";
-import { Tests } from "../../../../../utils/types";
 import { typingExpectation } from "../../../../../utils/sharedTests/sharedFunctionsAndVariables";
+import { testSqlConsole } from "../../../../../utils/sharedTests/sqlEditor";
+import { Tests } from "../../../../../utils/types";
 
 const pageName = "Database page (corona-virus) with tables and docs";
 const currentOwner = "automated_testing";
@@ -89,7 +91,7 @@ describe(`${pageName} renders expected components on different devices`, () => {
     iPad2ForAppLayout(pageName, desktopAndIpadTests(true)),
     iPhoneXForAppLayout(
       pageName,
-      mobileTests(currentOwner, currentRepo, currentPage, hasDocs, hasBranch),
+      testMobileRepoHeaderNav(currentOwner, currentRepo),
     ),
   ];
   const skip = false;

--- a/cypress/integration/dolthub/productionTests/publicPaths/render/database/docsNoTables.spec.ts
+++ b/cypress/integration/dolthub/productionTests/publicPaths/render/database/docsNoTables.spec.ts
@@ -5,14 +5,16 @@ import {
   macbook15ForAppLayout,
 } from "../../../../../utils/devices";
 import { newExpectation, newShouldArgs } from "../../../../../utils/helpers";
-import { testRepoHeaderWithBranch } from "../../../../../utils/sharedTests/repoHeaderNav";
+import {
+  testMobileRepoHeaderNav,
+  testRepoHeaderWithBranch,
+} from "../../../../../utils/sharedTests/repoHeaderNav";
 import {
   tableExpectations,
   testQueryCatalogSection,
   testSchemaSection,
   testViewsSection,
 } from "../../../../../utils/sharedTests/repoLeftNav";
-import { mobileTests } from "../../../../../utils/sharedTests/testRepoPageMobile";
 import { Tests } from "../../../../../utils/types";
 
 const pageName = "Database page with docs and no tables";
@@ -61,7 +63,7 @@ describe(`${pageName} renders expected components on different devices`, () => {
     iPad2ForAppLayout(pageName, desktopAndIpadTests(true)),
     iPhoneXForAppLayout(
       pageName,
-      mobileTests(currentOwner, currentRepo, currentPage, hasDocs, hasBranch),
+      testMobileRepoHeaderNav(currentOwner, currentRepo),
     ),
   ];
   const skip = false;

--- a/cypress/integration/dolthub/productionTests/publicPaths/render/database/empty.spec.ts
+++ b/cypress/integration/dolthub/productionTests/publicPaths/render/database/empty.spec.ts
@@ -10,7 +10,10 @@ import {
   newShouldArgs,
 } from "../../../../../utils/helpers";
 import { testDoltInstallationSteps } from "../../../../../utils/sharedTests/emptyRepo";
-import { testRepoHeaderForAll } from "../../../../../utils/sharedTests/repoHeaderNav";
+import {
+  testMobileRepoHeaderNav,
+  testRepoHeaderForAll,
+} from "../../../../../utils/sharedTests/repoHeaderNav";
 import {
   testQueryCatalogSection,
   testSchemaSection,
@@ -18,7 +21,6 @@ import {
   testViewsSection,
 } from "../../../../../utils/sharedTests/repoLeftNav";
 import { testSqlConsole } from "../../../../../utils/sharedTests/sqlEditor";
-import { mobileTests } from "../../../../../utils/sharedTests/testRepoPageMobile";
 
 const pageName = "Database page with no branch and no data";
 const currentOwner = "automated_testing";
@@ -27,7 +29,6 @@ const currentPage = `repositories/${currentOwner}/${currentRepo}`;
 const loggedIn = false;
 const hasDocs = false;
 const hasBranch = false;
-const hasData = false;
 
 describe(`${pageName} renders expected components on different devices`, () => {
   const beVisible = newShouldArgs("be.visible");
@@ -95,14 +96,7 @@ describe(`${pageName} renders expected components on different devices`, () => {
     iPad2ForAppLayout(pageName, desktopAndIpadTests(true)),
     iPhoneXForAppLayout(
       pageName,
-      mobileTests(
-        currentOwner,
-        currentRepo,
-        currentPage,
-        hasDocs,
-        hasBranch,
-        hasData,
-      ),
+      testMobileRepoHeaderNav(currentOwner, currentRepo),
     ),
   ];
   runTestsForDevices({ currentPage, devices });

--- a/cypress/integration/dolthub/productionTests/publicPaths/render/database/emptyWithBranch.spec.ts
+++ b/cypress/integration/dolthub/productionTests/publicPaths/render/database/emptyWithBranch.spec.ts
@@ -10,7 +10,10 @@ import {
   newShouldArgs,
 } from "../../../../../utils/helpers";
 import { testDoltInstallationSteps } from "../../../../../utils/sharedTests/emptyRepo";
-import { testRepoHeaderWithBranch } from "../../../../../utils/sharedTests/repoHeaderNav";
+import {
+  testMobileRepoHeaderNav,
+  testRepoHeaderWithBranch,
+} from "../../../../../utils/sharedTests/repoHeaderNav";
 import {
   testQueryCatalogSection,
   testSchemaSection,
@@ -18,7 +21,6 @@ import {
   testViewsSection,
 } from "../../../../../utils/sharedTests/repoLeftNav";
 import { testSqlConsole } from "../../../../../utils/sharedTests/sqlEditor";
-import { mobileTests } from "../../../../../utils/sharedTests/testRepoPageMobile";
 
 const pageName = "Database page with branch and no data";
 const currentOwner = "automated_testing";
@@ -27,7 +29,6 @@ const currentPage = `repositories/${currentOwner}/${currentRepo}`;
 const loggedIn = false;
 const hasDocs = false;
 const hasBranch = true;
-const hasData = false;
 
 describe(`${pageName} renders expected components on different devices`, () => {
   const beVisible = newShouldArgs("be.visible");
@@ -90,14 +91,7 @@ describe(`${pageName} renders expected components on different devices`, () => {
     iPad2ForAppLayout(pageName, desktopAndIpadTests(true)),
     iPhoneXForAppLayout(
       pageName,
-      mobileTests(
-        currentOwner,
-        currentRepo,
-        currentPage,
-        hasDocs,
-        hasBranch,
-        hasData,
-      ),
+      testMobileRepoHeaderNav(currentOwner, currentRepo),
     ),
   ];
 

--- a/cypress/integration/dolthub/productionTests/publicPaths/render/database/forked.spec.ts
+++ b/cypress/integration/dolthub/productionTests/publicPaths/render/database/forked.spec.ts
@@ -45,7 +45,7 @@ describe(`${pageName} renders expected components on different devices`, () => {
     ),
     newExpectation(
       "should display data columns",
-      "[data-cy=repo-data-table-columns] > th",
+      "[data-cy=desktop-repo-data-table-columns] > th",
       newShouldArgs("be.visible.and.have.length", 8),
     ),
     ...testRepoHeaderWithBranch(

--- a/cypress/integration/dolthub/productionTests/publicPaths/render/database/forked.spec.ts
+++ b/cypress/integration/dolthub/productionTests/publicPaths/render/database/forked.spec.ts
@@ -5,7 +5,10 @@ import {
   macbook15ForAppLayout,
 } from "../../../../../utils/devices";
 import { newExpectation, newShouldArgs } from "../../../../../utils/helpers";
-import { testRepoHeaderWithBranch } from "../../../../../utils/sharedTests/repoHeaderNav";
+import {
+  testMobileRepoHeaderNav,
+  testRepoHeaderWithBranch,
+} from "../../../../../utils/sharedTests/repoHeaderNav";
 import {
   tableExpectations,
   testQueryCatalogSection,
@@ -13,7 +16,6 @@ import {
   testViewsSection,
 } from "../../../../../utils/sharedTests/repoLeftNav";
 import { testSqlConsole } from "../../../../../utils/sharedTests/sqlEditor";
-import { mobileTests } from "../../../../../utils/sharedTests/testRepoPageMobile";
 
 const pageName = "Forked database page";
 const currentOwner = "automated_testing";
@@ -35,7 +37,7 @@ describe(`${pageName} renders expected components on different devices`, () => {
     ),
     newExpectation(
       "should find database table data",
-      "[data-cy=repo-data-table]",
+      "[data-cy=desktop-repo-data-table]",
       beVisible,
     ),
     newExpectation(
@@ -72,7 +74,7 @@ describe(`${pageName} renders expected components on different devices`, () => {
     iPad2ForAppLayout(pageName, desktopAndIpadTests(true), true),
     iPhoneXForAppLayout(
       pageName,
-      mobileTests(currentOwner, currentRepo, currentPage, hasDocs, hasBranch),
+      testMobileRepoHeaderNav(currentOwner, currentRepo),
       true,
     ),
   ];

--- a/cypress/integration/dolthub/productionTests/publicPaths/render/database/ngrams.spec.ts
+++ b/cypress/integration/dolthub/productionTests/publicPaths/render/database/ngrams.spec.ts
@@ -73,7 +73,7 @@ describe(`${pageName} renders expected components on different devices`, () => {
       ),
       newExpectation(
         "",
-        "[data-cy=repo-data-table-row-1-col-0]",
+        "[data-cy=desktop-repo-data-table-row-1-col-0]",
         newShouldArgs("be.visible.and.contain", "8-01-19"),
       ),
     ],
@@ -84,12 +84,12 @@ describe(`${pageName} renders expected components on different devices`, () => {
     [
       newExpectation(
         "",
-        "[data-cy=repo-data-table-column-trigram]",
+        "[data-cy=desktop-repo-data-table-column-trigram]",
         newShouldArgs("be.visible.and.contain", "trigram"),
       ),
       newExpectation(
         "",
-        "[data-cy=repo-data-table-row-0-col-2]",
+        "[data-cy=desktop-repo-data-table-row-0-col-2]",
         newShouldArgs("be.visible.and.contain", "113"),
       ),
     ],
@@ -100,12 +100,12 @@ describe(`${pageName} renders expected components on different devices`, () => {
     [
       newExpectation(
         "",
-        "[data-cy=repo-data-table-column-unigram]",
+        "[data-cy=desktop-repo-data-table-column-unigram]",
         newShouldArgs("be.visible.and.contain", "unigram"),
       ),
       newExpectation(
         "",
-        "[data-cy=repo-data-table-row-0-col-1]",
+        "[data-cy=desktop-repo-data-table-row-0-col-1]",
         newShouldArgs("be.visible.and.contain", "65929"),
       ),
     ],
@@ -116,12 +116,12 @@ describe(`${pageName} renders expected components on different devices`, () => {
     [
       newExpectation(
         "",
-        "[data-cy=repo-data-table-column-bigram]",
+        "[data-cy=desktop-repo-data-table-column-bigram]",
         newShouldArgs("be.visible.and.contain", "bigram"),
       ),
       newExpectation(
         "",
-        "[data-cy=repo-data-table-row-0-col-2]",
+        "[data-cy=desktop-repo-data-table-row-0-col-2]",
         newShouldArgs("be.visible.and.contain", "1444"),
       ),
     ],
@@ -209,12 +209,12 @@ describe(`${pageName} renders expected components on different devices`, () => {
     ),
     newExpectation(
       "should display repo data columns",
-      "[data-cy=repo-data-table-columns] > th",
+      "[data-cy=desktop-repo-data-table-columns] > th",
       newShouldArgs("be.visible.and.have.length", 4),
     ),
     newExpectation(
       "should display repo data row column values",
-      "[data-cy=repo-data-table-row-0-col-1]",
+      "[data-cy=desktop-repo-data-table-row-0-col-1]",
       newShouldArgs("be.visible.and.contain", "3071"),
     ),
     ...tableExpectations(hasDocs, loggedIn, 4, "bigram_counts"),

--- a/cypress/integration/dolthub/productionTests/publicPaths/render/database/ngrams.spec.ts
+++ b/cypress/integration/dolthub/productionTests/publicPaths/render/database/ngrams.spec.ts
@@ -10,7 +10,10 @@ import {
   newShouldArgs,
 } from "../../../../../utils/helpers";
 import { testPaginationForRepoDataTable } from "../../../../../utils/sharedTests/pagination";
-import { testRepoHeaderWithBranch } from "../../../../../utils/sharedTests/repoHeaderNav";
+import {
+  testMobileRepoHeaderNav,
+  testRepoHeaderWithBranch,
+} from "../../../../../utils/sharedTests/repoHeaderNav";
 import {
   tableExpectations,
   testQueryCatalogSection,
@@ -18,7 +21,6 @@ import {
   testViewsSection,
 } from "../../../../../utils/sharedTests/repoLeftNav";
 import { testSqlConsole } from "../../../../../utils/sharedTests/sqlEditor";
-import { mobileTests } from "../../../../../utils/sharedTests/testRepoPageMobile";
 
 const pageName = "Database page (wikipedia-ngrams) with tables";
 const currentOwner = "automated_testing";
@@ -242,7 +244,7 @@ describe(`${pageName} renders expected components on different devices`, () => {
     // iPad2ForAppLayout(pageName, desktopAndIpadTests(true), true), // Not optimized for ipad, test is flaky
     iPhoneXForAppLayout(
       pageName,
-      mobileTests(currentOwner, currentRepo, currentPage, hasDocs, hasBranch),
+      testMobileRepoHeaderNav(currentOwner, currentRepo),
       true,
     ),
   ];

--- a/cypress/integration/dolthub/productionTests/publicPaths/render/database/tablesAndDocs.spec.ts
+++ b/cypress/integration/dolthub/productionTests/publicPaths/render/database/tablesAndDocs.spec.ts
@@ -5,7 +5,10 @@ import {
   macbook15ForAppLayout,
 } from "../../../../../utils/devices";
 import { newExpectation, newShouldArgs } from "../../../../../utils/helpers";
-import { testRepoHeaderWithBranch } from "../../../../../utils/sharedTests/repoHeaderNav";
+import {
+  testMobileRepoHeaderNav,
+  testRepoHeaderWithBranch,
+} from "../../../../../utils/sharedTests/repoHeaderNav";
 import {
   tableExpectations,
   testQueryCatalogSection,
@@ -13,7 +16,6 @@ import {
   testViewsSection,
 } from "../../../../../utils/sharedTests/repoLeftNav";
 import { testSqlConsole } from "../../../../../utils/sharedTests/sqlEditor";
-import { mobileTests } from "../../../../../utils/sharedTests/testRepoPageMobile";
 
 const pageName = "Database page with tables and docs";
 const currentOwner = "automated_testing";
@@ -62,7 +64,7 @@ describe(`${pageName} renders expected components on different devices`, () => {
     iPad2ForAppLayout(pageName, desktopAndIpadTests(true)),
     iPhoneXForAppLayout(
       pageName,
-      mobileTests(currentOwner, currentRepo, currentPage, hasDocs, hasBranch),
+      testMobileRepoHeaderNav(currentOwner, currentRepo),
     ),
   ];
   const skip = false;

--- a/cypress/integration/dolthub/productionTests/publicPaths/render/database/tablesNoDocs.spec.ts
+++ b/cypress/integration/dolthub/productionTests/publicPaths/render/database/tablesNoDocs.spec.ts
@@ -58,12 +58,12 @@ describe(`${pageName} renders expected components on different devices`, () => {
     ),
     newExpectation(
       "should display data columns",
-      "[data-cy=repo-data-table-columns] > th",
+      "[data-cy=desktop-repo-data-table-columns] > th",
       newShouldArgs("be.visible.and.have.length", 5),
     ),
     newExpectation(
       "should display database data row column values",
-      "[data-cy=repo-data-table-row-0-col-1]",
+      "[data-cy=desktop-repo-data-table-row-0-col-1]",
       newShouldArgs("be.visible.and.contain", "b"),
     ),
     newExpectationWithScrollIntoView(

--- a/cypress/integration/dolthub/productionTests/publicPaths/render/database/tablesNoDocs.spec.ts
+++ b/cypress/integration/dolthub/productionTests/publicPaths/render/database/tablesNoDocs.spec.ts
@@ -11,7 +11,10 @@ import {
   newExpectationWithScrollIntoView,
   newShouldArgs,
 } from "../../../../../utils/helpers";
-import { testRepoHeaderWithBranch } from "../../../../../utils/sharedTests/repoHeaderNav";
+import {
+  testMobileRepoHeaderNav,
+  testRepoHeaderWithBranch,
+} from "../../../../../utils/sharedTests/repoHeaderNav";
 import {
   tableExpectations,
   testQueryCatalogSection,
@@ -19,7 +22,6 @@ import {
   testViewsSection,
 } from "../../../../../utils/sharedTests/repoLeftNav";
 import { testSqlConsole } from "../../../../../utils/sharedTests/sqlEditor";
-import { mobileTests } from "../../../../../utils/sharedTests/testRepoPageMobile";
 
 const pageName = "Database page with tables and no docs";
 const currentOwner = "automated_testing";
@@ -48,7 +50,7 @@ describe(`${pageName} renders expected components on different devices`, () => {
     ),
     newExpectation(
       "should find database table data",
-      "[data-cy=repo-data-table]",
+      "[data-cy=desktop-repo-data-table]",
       beVisible,
     ),
     newExpectation(
@@ -108,7 +110,7 @@ describe(`${pageName} renders expected components on different devices`, () => {
     iPad2ForAppLayout(pageName, desktopAndIpadTests(true), true),
     iPhoneXForAppLayout(
       pageName,
-      mobileTests(currentOwner, currentRepo, currentPage, hasDocs, hasBranch),
+      testMobileRepoHeaderNav(currentOwner, currentRepo),
       true,
     ),
   ];

--- a/cypress/integration/dolthub/productionTests/publicPaths/render/database/tags.spec.ts
+++ b/cypress/integration/dolthub/productionTests/publicPaths/render/database/tags.spec.ts
@@ -11,7 +11,10 @@ import {
   newExpectationWithClickFlows,
   newShouldArgs,
 } from "../../../../../utils/helpers";
-import { testRepoHeaderWithBranch } from "../../../../../utils/sharedTests/repoHeaderNav";
+import {
+  testMobileRepoHeaderNav,
+  testRepoHeaderWithBranch,
+} from "../../../../../utils/sharedTests/repoHeaderNav";
 import {
   tableExpectations,
   testQueryCatalogSection,
@@ -19,7 +22,6 @@ import {
   testViewsSection,
 } from "../../../../../utils/sharedTests/repoLeftNav";
 import { testSqlConsole } from "../../../../../utils/sharedTests/sqlEditor";
-import { mobileTests } from "../../../../../utils/sharedTests/testRepoPageMobile";
 import { Expectation } from "../../../../../utils/types";
 
 const pageName = "Database page with tags and branches";
@@ -59,7 +61,7 @@ describe(`${pageName} renders expected components on different devices`, () => {
     iPad2ForAppLayout(pageName, desktopAndIpadTests(true)),
     iPhoneXForAppLayout(
       pageName,
-      mobileTests(currentOwner, currentRepo, currentPage, hasDocs, hasBranch),
+      testMobileRepoHeaderNav(currentOwner, currentRepo),
     ),
   ];
   const skip = false;

--- a/cypress/integration/dolthub/productionTests/publicPaths/render/workspaces/selectQuery.spec.ts
+++ b/cypress/integration/dolthub/productionTests/publicPaths/render/workspaces/selectQuery.spec.ts
@@ -75,7 +75,7 @@ describe(`${pageName} renders expected components on different devices`, () => {
     ),
     newExpectation(
       "should show data table",
-      "[data-cy=repo-data-table]",
+      "[data-cy=desktop-repo-data-table]",
       beVisible,
     ),
     newExpectation(

--- a/cypress/integration/utils/sharedTests/pagination.ts
+++ b/cypress/integration/utils/sharedTests/pagination.ts
@@ -64,7 +64,7 @@ export const testPaginationForList = (
   );
 
 export const testPaginationForRepoDataTable = testPaginationForTable(
-  "[data-cy=repo-data-table]",
+  "[data-cy=desktop-repo-data-table]",
   "[id=main-content]",
   51,
 );

--- a/cypress/integration/utils/sharedTests/repoHeaderNav.ts
+++ b/cypress/integration/utils/sharedTests/repoHeaderNav.ts
@@ -227,9 +227,9 @@ export const testRepoHeaderForAll = (
     ? [
         ...testCommonHeader(repoName, ownerName),
         newExpectation(
-          "should not have repo clone button",
+          "should  have repo clone button",
           "[data-cy=repo-clone-button]",
-          notBeVisible,
+          beVisible,
         ),
         ...testTabs(beVisible),
         newExpectation(

--- a/cypress/integration/utils/sharedTests/repoHeaderNav.ts
+++ b/cypress/integration/utils/sharedTests/repoHeaderNav.ts
@@ -227,9 +227,9 @@ export const testRepoHeaderForAll = (
     ? [
         ...testCommonHeader(repoName, ownerName),
         newExpectation(
-          "should  have repo clone button",
+          "should  not have repo clone button",
           "[data-cy=repo-clone-button]",
-          beVisible,
+          notBeVisible,
         ),
         ...testTabs(beVisible),
         newExpectation(

--- a/cypress/integration/utils/sharedTests/repoLeftNav.ts
+++ b/cypress/integration/utils/sharedTests/repoLeftNav.ts
@@ -240,13 +240,13 @@ export const testClickDeleteRow = (
   return [
     newExpectationWithClickFlows(
       "should click first row dropdown button",
-      "[data-cy=repo-data-table-row-0-col-0]",
+      "[data-cy=desktop-repo-data-table-row-0-col-0]",
       beVisible,
       [
         newClickFlow(
-          "[data-cy=row-dropdown-button]:first",
+          "[data-cy=desktop-row-dropdown-button]:first",
           [],
-          "[data-cy=delete-row-button]",
+          "[data-cy=desktop-delete-row-button]",
           true,
         ),
       ],


### PR DESCRIPTION
- use `desktop-` data-cy for testing elements in DataTable component.

- testMobileRepoHeaderNav instead of mobileTests(testMobileRepoHeaderNav and mobileWarnings) for database pages.