### PR TITLE
liuliu/test-for-dev-and-default-viewport-fix

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -14,4 +14,6 @@ export default defineConfig({
     specPattern:
       "cypress/integration/dolthub/productionTests/**/*.{js,jsx,ts,tsx}",
   },
+  viewportWidth: 1440,
+  viewportHeight: 900,
 });

--- a/cypress/integration/dolthub/productionTests/publicPaths/render/pull/coronaMergedPullDiff.spec.ts
+++ b/cypress/integration/dolthub/productionTests/publicPaths/render/pull/coronaMergedPullDiff.spec.ts
@@ -32,7 +32,7 @@ describe(`${pageName} renders expected components on different devices`, () => {
     newExpectation(
       "should show diff selector",
       "[data-cy=diff-selector]",
-      newShouldArgs("be.visible.and.contain", "all commits"),
+      beVisible,
     ),
     newExpectation(
       "should show one form select",

--- a/cypress/integration/dolthub/productionTests/publicPaths/render/pull/coronaOpenPullDiff.spec.ts
+++ b/cypress/integration/dolthub/productionTests/publicPaths/render/pull/coronaOpenPullDiff.spec.ts
@@ -30,7 +30,7 @@ describe(`${pageName} renders expected components on different devices`, () => {
     newExpectation(
       "should show diff selector",
       "[data-cy=diff-selector]",
-      newShouldArgs("be.visible.and.contain", "all commits"),
+      beVisible,
     ),
     newExpectation(
       "should show one form select",


### PR DESCRIPTION
- `diff-selector` on prod has text "all commits" while dev doesn't, change the assertion to be `BeVisible` instead of `BeVisibleAndContain`
- the default viewport is 1000 x 600, makes testing MacBook 15 viewport flaky, set the default one to match MacBook 15 resolution.