### PR TITLE
liuliu/clone-button-test-fix

### DIFF
--- a/cypress/e2e/utils/sharedTests/repoHeaderNav.ts
+++ b/cypress/e2e/utils/sharedTests/repoHeaderNav.ts
@@ -21,7 +21,7 @@ const cloneClickFlow = newClickFlow(
       newShouldArgs("be.visible.and.have.length", 2),
     ),
   ],
-  "#main-content",
+  "[data-cy=repo-clone-button]",
 );
 
 export const forkButtonClickFlow = (loggedIn: boolean) =>


### PR DESCRIPTION
click "#main-content" to close clone popup would sometimes cause it clicks into the links in the docs:

![Database page (corona-virus) with tables and docs renders expected components on different devices -- Database page (corona-virus) with tables and docs renders expected components on ipad-2 -- should click first row dropdown button (failed)](https://user-images.githubusercontent.com/6688812/211650917-0ebe30ae-4f68-495f-987b-8248a742ee86.png)
