### PR TITLE
liuliu/match-all-minified-error

### DIFF
--- a/cypress/e2e/utils/sharedTests/sharedFunctionsAndVariables.ts
+++ b/cypress/e2e/utils/sharedTests/sharedFunctionsAndVariables.ts
@@ -104,8 +104,4 @@ export function getTypeInGridTests(grids: string[][], skipClear = false) {
   return tests;
 }
 
-export const gatsbyServerBuildErrors = [
-  "Minified React error #425",
-  "Minified React error #418",
-  "Minified React error #423",
-];
+export const gatsbyServerBuildErrors = ["Minified React error"];


### PR DESCRIPTION
seems that sometimes cypress would ignore the error but sometimes would fail to recognize that error
make the error massage shorter to see if cypress can catch them all