### PR TITLE
Change time of dependency bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,20 +4,10 @@ updates:
   directory: "/"
   schedule:
     interval: monthly
-    time: "06:30"
+    time: "08:30"
     timezone: America/Los_Angeles
   open-pull-requests-limit: 10
   reviewers:
   - liuliu-dev
   labels:
   - dependencies
-  ignore:
-  - dependency-name: "@babel/preset-env"
-    versions:
-    - 7.13.8
-  - dependency-name: "@types/node"
-    versions:
-    - 14.14.31
-  - dependency-name: cypress
-    versions:
-    - 6.3.0


### PR DESCRIPTION
Seems like the tests running for all the dependency bumps caused a dolthub outage on 11/1.  I'll be on call again on 12/1 and if this was the cause of the outage it would be better to deal with not at 6am :)