### PR TITLE
Fix flaky pricing enterprise banner click on macbook-15

### DIFF
--- a/cypress/e2e/dolthub/publicPaths/render/pricing/index.spec.ts
+++ b/cypress/e2e/dolthub/publicPaths/render/pricing/index.spec.ts
@@ -136,6 +136,15 @@ describe(`${pageName} renders expected components on different devices`, () => {
                   options: { offset: { top: -100, left: 0 } },
                 },
               ),
+              newExpectationWithScrollTo(
+                `should scroll ${test.name} enterprise banner into view`,
+                `[data-cy=enterprise-banner-${test.name}]`,
+                beVisible,
+                {
+                  selectorStr: `[data-cy=enterprise-banner-${test.name}]`,
+                  options: { offset: { top: -100, left: 0 } },
+                },
+              ),
               newExpectationWithClickFlow(
                 "should click on the enterprise banner button",
                 `[data-cy=enterprise-banner-${test.name}]`,

--- a/cypress/e2e/dolthub/publicPaths/render/pricing/index.spec.ts
+++ b/cypress/e2e/dolthub/publicPaths/render/pricing/index.spec.ts
@@ -136,26 +136,22 @@ describe(`${pageName} renders expected components on different devices`, () => {
                   options: { offset: { top: -100, left: 0 } },
                 },
               ),
-              newExpectationWithScrollTo(
-                `should scroll ${test.name} enterprise banner into view`,
-                `[data-cy=enterprise-banner-${test.name}]`,
-                beVisible,
-                {
-                  selectorStr: `[data-cy=enterprise-banner-${test.name}]`,
-                  options: { offset: { top: -100, left: 0 } },
-                },
-              ),
               newExpectationWithClickFlow(
                 "should click on the enterprise banner button",
                 `[data-cy=enterprise-banner-${test.name}]`,
                 beVisible,
-                newClickFlow(`[data-cy=enterprise-banner-${test.name}]`, [
-                  newExpectation(
-                    "should find the enterprise card",
-                    `[data-cy=enterprise-card]`,
-                    beVisible,
-                  ),
-                ]),
+                newClickFlow(
+                  `[data-cy=enterprise-banner-${test.name}]`,
+                  [
+                    newExpectation(
+                      "should find the enterprise card",
+                      `[data-cy=enterprise-card]`,
+                      beVisible,
+                    ),
+                  ],
+                  undefined,
+                  true,
+                ),
               ),
             ]
           : []),


### PR DESCRIPTION
Scroll the enterprise banner into view (with sticky-nav offset) before clicking. Previously only the card header was scrolled into view, so on 1440x900 viewports the banner could land below the fold or under a sticky element, causing intermittent "center of this element is hidden from view" failures from cy.click() (which can't auto-scroll because clickOpts.scrollBehavior is false).