### PR TITLE
Add cypress tests for OAuth applications settings page

### DIFF
--- a/cypress/e2e/dolthub/privatePaths/render/settings/apps.spec.ts
+++ b/cypress/e2e/dolthub/privatePaths/render/settings/apps.spec.ts
@@ -1,4 +1,7 @@
-import { beVisible } from "@sharedTests/sharedFunctionsAndVariables";
+import {
+  beVisible,
+  shouldBeVisible,
+} from "@sharedTests/sharedFunctionsAndVariables";
 import { macbook15ForAppLayout } from "@utils/devices";
 import {
   newClickFlow,
@@ -12,62 +15,37 @@ const pageName = "Apps Settings";
 const currentPage = "/settings/apps";
 
 const loggedIn = true;
-
 const skip = false;
 
 const newAppFormClickFlow = newClickFlow(
   "[data-cy=new-oauth-app-button]",
   [
-    newExpectation(
-      "should render the create OAuth app form",
-      "[data-cy=create-oauth-app-form]",
-      beVisible,
-    ),
-    newExpectation(
-      "should render breadcrumb back to OAuth Applications",
-      "[data-cy=oauth-applications-back-link]",
-      beVisible,
-    ),
-    newExpectation(
-      "should render the Application name input",
-      "[data-cy=create-oauth-app-form]",
-      beVisible,
+    shouldBeVisible("create-oauth-app-form", "create OAuth app form"),
+    shouldBeVisible(
+      "oauth-applications-back-link",
+      "breadcrumb back to OAuth Applications",
     ),
     newExpectation(
       "should render a disabled Register application button",
       "[data-cy=register-oauth-application-button]",
       newShouldArgs("be.disabled"),
     ),
-    newExpectation(
-      "should render a Cancel link",
-      "[data-cy=cancel-create-oauth-app]",
-      beVisible,
-    ),
+    shouldBeVisible("cancel-create-oauth-app", "Cancel link"),
   ],
   "[data-cy=cancel-create-oauth-app]",
 );
 
 describe(`${pageName} renders expected components on different devices`, () => {
   const tests = [
-    newExpectation(
-      "should render Settings header",
-      "[data-cy=settings-header]",
-      beVisible,
+    shouldBeVisible("settings-header", "Settings header"),
+    shouldBeVisible("settings-apps-section-link", "Settings Apps link"),
+    shouldBeVisible(
+      "oauth-applications-heading",
+      "OAuth Applications heading",
     ),
-    newExpectation(
-      "should render Settings Apps link",
-      "[data-cy=settings-apps-section-link]",
-      beVisible,
-    ),
-    newExpectation(
-      "should render the OAuth Applications heading",
-      "[data-cy=oauth-applications-heading]",
-      beVisible,
-    ),
-    newExpectation(
-      "should render the Authorized Applications heading",
-      "[data-cy=authorized-applications-heading]",
-      beVisible,
+    shouldBeVisible(
+      "authorized-applications-heading",
+      "Authorized Applications heading",
     ),
     newExpectationWithClickFlow(
       "clicking New OAuth App should open the form, then Cancel returns to the Apps page",

--- a/cypress/e2e/dolthub/privatePaths/render/settings/apps.spec.ts
+++ b/cypress/e2e/dolthub/privatePaths/render/settings/apps.spec.ts
@@ -13,10 +13,7 @@ const currentPage = "/settings/apps";
 
 const loggedIn = true;
 
-// The OAuth feature is gated behind the `oauth` feature flag (currently
-// dev-only). Once OAuth ships to prod, flip `skip` to false to enable
-// these tests.
-const skip = true;
+const skip = false;
 
 const newAppFormClickFlow = newClickFlow(
   "[data-cy=new-oauth-app-button]",

--- a/cypress/e2e/dolthub/privatePaths/render/settings/apps.spec.ts
+++ b/cypress/e2e/dolthub/privatePaths/render/settings/apps.spec.ts
@@ -1,6 +1,7 @@
 import {
   beVisible,
   shouldBeVisible,
+  shouldBeVisibleAndScrollIntoView,
 } from "@sharedTests/sharedFunctionsAndVariables";
 import { macbook15ForAppLayout } from "@utils/devices";
 import {
@@ -30,7 +31,7 @@ const newAppFormClickFlow = newClickFlow(
       "[data-cy=register-oauth-application-button]",
       newShouldArgs("be.disabled"),
     ),
-    shouldBeVisible("cancel-create-oauth-app", "Cancel link"),
+    shouldBeVisibleAndScrollIntoView("cancel-create-oauth-app", "Cancel link"),
   ],
   "[data-cy=cancel-create-oauth-app]",
 );

--- a/cypress/e2e/dolthub/privatePaths/render/settings/apps.spec.ts
+++ b/cypress/e2e/dolthub/privatePaths/render/settings/apps.spec.ts
@@ -1,0 +1,84 @@
+import { beVisible } from "@sharedTests/sharedFunctionsAndVariables";
+import { macbook15ForAppLayout } from "@utils/devices";
+import {
+  newClickFlow,
+  newExpectation,
+  newExpectationWithClickFlow,
+  newShouldArgs,
+} from "@utils/helpers";
+import { runTestsForDevices } from "@utils/index";
+
+const pageName = "Apps Settings";
+const currentPage = "/settings/apps";
+
+const loggedIn = true;
+
+// The OAuth feature is gated behind the `oauth` feature flag (currently
+// dev-only). Once OAuth ships to prod, flip `skip` to false to enable
+// these tests.
+const skip = true;
+
+const newAppFormClickFlow = newClickFlow(
+  "[data-cy=new-oauth-app-button]",
+  [
+    newExpectation(
+      "should render the create OAuth app form",
+      "[data-cy=create-oauth-app-form]",
+      beVisible,
+    ),
+    newExpectation(
+      "should render breadcrumb back to OAuth Applications",
+      "[data-cy=oauth-applications-back-link]",
+      beVisible,
+    ),
+    newExpectation(
+      "should render the Application name input",
+      "[data-cy=create-oauth-app-form]",
+      beVisible,
+    ),
+    newExpectation(
+      "should render a disabled Register application button",
+      "[data-cy=register-oauth-application-button]",
+      newShouldArgs("be.disabled"),
+    ),
+    newExpectation(
+      "should render a Cancel link",
+      "[data-cy=cancel-create-oauth-app]",
+      beVisible,
+    ),
+  ],
+  "[data-cy=cancel-create-oauth-app]",
+);
+
+describe(`${pageName} renders expected components on different devices`, () => {
+  const tests = [
+    newExpectation(
+      "should render Settings header",
+      "[data-cy=settings-header]",
+      beVisible,
+    ),
+    newExpectation(
+      "should render Settings Apps link",
+      "[data-cy=settings-apps-section-link]",
+      beVisible,
+    ),
+    newExpectation(
+      "should render the OAuth Applications heading",
+      "[data-cy=oauth-applications-heading]",
+      beVisible,
+    ),
+    newExpectation(
+      "should render the Authorized Applications heading",
+      "[data-cy=authorized-applications-heading]",
+      beVisible,
+    ),
+    newExpectationWithClickFlow(
+      "clicking New OAuth App should open the form, then Cancel returns to the Apps page",
+      "[data-cy=new-oauth-app-button]",
+      beVisible,
+      newAppFormClickFlow,
+    ),
+  ];
+  const devices = [macbook15ForAppLayout(pageName, tests, false, loggedIn)];
+  runTestsForDevices({ currentPage, devices, skip, loggedIn });
+});

--- a/cypress/e2e/dolthub/privatePaths/render/settings/apps.spec.ts
+++ b/cypress/e2e/dolthub/privatePaths/render/settings/apps.spec.ts
@@ -39,10 +39,7 @@ describe(`${pageName} renders expected components on different devices`, () => {
   const tests = [
     shouldBeVisible("settings-header", "Settings header"),
     shouldBeVisible("settings-apps-section-link", "Settings Apps link"),
-    shouldBeVisible(
-      "oauth-applications-heading",
-      "OAuth Applications heading",
-    ),
+    shouldBeVisible("oauth-applications-heading", "OAuth Applications heading"),
     shouldBeVisible(
       "authorized-applications-heading",
       "Authorized Applications heading",

--- a/cypress/e2e/dolthub/privatePaths/render/settings/apps/new.spec.ts
+++ b/cypress/e2e/dolthub/privatePaths/render/settings/apps/new.spec.ts
@@ -8,10 +8,7 @@ const currentPage = "/settings/apps/new";
 
 const loggedIn = true;
 
-// The OAuth feature is gated behind the `oauth` feature flag (currently
-// dev-only). Once OAuth ships to prod, flip `skip` to false to enable
-// these tests.
-const skip = true;
+const skip = false;
 
 describe(`${pageName} renders expected components on different devices`, () => {
   const tests = [

--- a/cypress/e2e/dolthub/privatePaths/render/settings/apps/new.spec.ts
+++ b/cypress/e2e/dolthub/privatePaths/render/settings/apps/new.spec.ts
@@ -1,4 +1,4 @@
-import { beVisible } from "@sharedTests/sharedFunctionsAndVariables";
+import { shouldBeVisible } from "@sharedTests/sharedFunctionsAndVariables";
 import { macbook15ForAppLayout } from "@utils/devices";
 import { newExpectation, newShouldArgs } from "@utils/helpers";
 import { runTestsForDevices } from "@utils/index";
@@ -7,36 +7,19 @@ const pageName = "New OAuth App Page";
 const currentPage = "/settings/apps/new";
 
 const loggedIn = true;
-
 const skip = false;
 
 describe(`${pageName} renders expected components on different devices`, () => {
   const tests = [
-    newExpectation(
-      "should render Settings header",
-      "[data-cy=settings-header]",
-      beVisible,
-    ),
-    newExpectation(
-      "should render the create OAuth app form",
-      "[data-cy=create-oauth-app-form]",
-      beVisible,
-    ),
-    newExpectation(
-      "should render breadcrumb back link",
-      "[data-cy=oauth-applications-back-link]",
-      beVisible,
-    ),
+    shouldBeVisible("settings-header", "Settings header"),
+    shouldBeVisible("create-oauth-app-form", "create OAuth app form"),
+    shouldBeVisible("oauth-applications-back-link", "breadcrumb back link"),
     newExpectation(
       "should render a disabled Register application button on initial load",
       "[data-cy=register-oauth-application-button]",
       newShouldArgs("be.disabled"),
     ),
-    newExpectation(
-      "should render a Cancel link",
-      "[data-cy=cancel-create-oauth-app]",
-      beVisible,
-    ),
+    shouldBeVisible("cancel-create-oauth-app", "Cancel link"),
   ];
   const devices = [macbook15ForAppLayout(pageName, tests, false, loggedIn)];
   runTestsForDevices({ currentPage, devices, skip, loggedIn });

--- a/cypress/e2e/dolthub/privatePaths/render/settings/apps/new.spec.ts
+++ b/cypress/e2e/dolthub/privatePaths/render/settings/apps/new.spec.ts
@@ -1,0 +1,46 @@
+import { beVisible } from "@sharedTests/sharedFunctionsAndVariables";
+import { macbook15ForAppLayout } from "@utils/devices";
+import { newExpectation, newShouldArgs } from "@utils/helpers";
+import { runTestsForDevices } from "@utils/index";
+
+const pageName = "New OAuth App Page";
+const currentPage = "/settings/apps/new";
+
+const loggedIn = true;
+
+// The OAuth feature is gated behind the `oauth` feature flag (currently
+// dev-only). Once OAuth ships to prod, flip `skip` to false to enable
+// these tests.
+const skip = true;
+
+describe(`${pageName} renders expected components on different devices`, () => {
+  const tests = [
+    newExpectation(
+      "should render Settings header",
+      "[data-cy=settings-header]",
+      beVisible,
+    ),
+    newExpectation(
+      "should render the create OAuth app form",
+      "[data-cy=create-oauth-app-form]",
+      beVisible,
+    ),
+    newExpectation(
+      "should render breadcrumb back link",
+      "[data-cy=oauth-applications-back-link]",
+      beVisible,
+    ),
+    newExpectation(
+      "should render a disabled Register application button on initial load",
+      "[data-cy=register-oauth-application-button]",
+      newShouldArgs("be.disabled"),
+    ),
+    newExpectation(
+      "should render a Cancel link",
+      "[data-cy=cancel-create-oauth-app]",
+      beVisible,
+    ),
+  ];
+  const devices = [macbook15ForAppLayout(pageName, tests, false, loggedIn)];
+  runTestsForDevices({ currentPage, devices, skip, loggedIn });
+});

--- a/cypress/e2e/dolthub/privatePaths/render/settings/apps/new.spec.ts
+++ b/cypress/e2e/dolthub/privatePaths/render/settings/apps/new.spec.ts
@@ -1,4 +1,7 @@
-import { shouldBeVisible } from "@sharedTests/sharedFunctionsAndVariables";
+import {
+  shouldBeVisible,
+  shouldBeVisibleAndScrollIntoView,
+} from "@sharedTests/sharedFunctionsAndVariables";
 import { macbook15ForAppLayout } from "@utils/devices";
 import { newExpectation, newShouldArgs } from "@utils/helpers";
 import { runTestsForDevices } from "@utils/index";
@@ -19,7 +22,7 @@ describe(`${pageName} renders expected components on different devices`, () => {
       "[data-cy=register-oauth-application-button]",
       newShouldArgs("be.disabled"),
     ),
-    shouldBeVisible("cancel-create-oauth-app", "Cancel link"),
+    shouldBeVisibleAndScrollIntoView("cancel-create-oauth-app", "Cancel link"),
   ];
   const devices = [macbook15ForAppLayout(pageName, tests, false, loggedIn)];
   runTestsForDevices({ currentPage, devices, skip, loggedIn });

--- a/cypress/e2e/dolthub/privatePaths/render/settings/index.spec.ts
+++ b/cypress/e2e/dolthub/privatePaths/render/settings/index.spec.ts
@@ -56,10 +56,9 @@ describe(`${pageName} renders expected components on different devices`, () => {
       false,
     ),
     newExpectation(
-      "should not render Apps link until OAuth ships to prod (oauth feature flag is dev-only)",
+      "should render Settings Apps link",
       "[data-cy=settings-apps-section-link]",
-      newShouldArgs("not.exist"),
-      false,
+      newShouldArgs("be.visible"),
     ),
   ];
   const skip = false;

--- a/cypress/e2e/dolthub/privatePaths/render/settings/index.spec.ts
+++ b/cypress/e2e/dolthub/privatePaths/render/settings/index.spec.ts
@@ -55,6 +55,12 @@ describe(`${pageName} renders expected components on different devices`, () => {
       newShouldArgs("not.exist"),
       false,
     ),
+    newExpectation(
+      "should not render Apps link until OAuth ships to prod (oauth feature flag is dev-only)",
+      "[data-cy=settings-apps-section-link]",
+      newShouldArgs("not.exist"),
+      false,
+    ),
   ];
   const skip = false;
   const devices = desktopDevicesForAppLayout(

--- a/cypress/e2e/dolthub/privatePaths/render/settings/index.spec.ts
+++ b/cypress/e2e/dolthub/privatePaths/render/settings/index.spec.ts
@@ -1,3 +1,4 @@
+import { shouldBeVisible } from "@sharedTests/sharedFunctionsAndVariables";
 import { desktopDevicesForAppLayout } from "@utils/devices";
 import { newExpectation, newShouldArgs } from "@utils/helpers";
 import { runTestsForDevices } from "@utils/index";
@@ -55,11 +56,7 @@ describe(`${pageName} renders expected components on different devices`, () => {
       newShouldArgs("not.exist"),
       false,
     ),
-    newExpectation(
-      "should render Settings Apps link",
-      "[data-cy=settings-apps-section-link]",
-      newShouldArgs("be.visible"),
-    ),
+    shouldBeVisible("settings-apps-section-link", "Settings Apps link"),
   ];
   const skip = false;
   const devices = desktopDevicesForAppLayout(


### PR DESCRIPTION
## Summary
Add cypress render + clickflow specs for the new OAuth applications settings UI.

The OAuth feature is currently behind the `oauth` feature flag (dev-only), so the new specs are marked **`skip = true`**. Once OAuth ships to prod, flip `skip` to `false`.

- `apps.spec.ts` — renders settings header, Apps link, OAuth Applications and Authorized Applications headings; clickflow opens the New OAuth App form and Cancel returns to the Apps page
- `apps/new.spec.ts` — renders the create form with breadcrumb back link, disabled `Register application` button, and Cancel link
- `index.spec.ts` — asserts the Apps link does **not** appear on prod for now (negative test that should be removed when OAuth GAs)

Companion PR adding `data-cy` hooks: dolthub/ld#23306 (taylor/oauth-cypress-data-cy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)