### PR TITLE
Add cypress tests for unauthenticated DoltHub v2 API endpoints

### DIFF
--- a/cypress/e2e/dolthub/publicPaths/apiV2/branches.spec.ts
+++ b/cypress/e2e/dolthub/publicPaths/apiV2/branches.spec.ts
@@ -1,0 +1,52 @@
+export {};
+
+const apiVersion = "v2";
+const repoOwner = "automated_testing";
+const repoName = "corona-virus";
+
+describe(`GET /${repoOwner}/${repoName}/branches returns branches`, () => {
+  const earl = `/api/${apiVersion}/databases/${repoOwner}/${repoName}/branches`;
+  it("gets a success response from the API", () => {
+    cy.request({ url: earl }).its("status").should("equal", 200);
+  });
+  it("contains an array of branches", () => {
+    cy.request({ url: earl })
+      .its("body.data")
+      .should("be.an", "array")
+      .and("have.length.above", 0);
+  });
+  it("contains the master branch with the expected fields", () => {
+    cy.request({ url: earl })
+      .its("body.data")
+      .then(branches => {
+        const master = branches.find(
+          (branch: { name: string }) => branch.name === "master",
+        );
+        expect(master).to.include.keys([
+          "name",
+          "head_commit_sha",
+          "last_updated_at",
+        ]);
+      });
+  });
+});
+
+describe(`GET /nonexistent_owner/nonexistent_database/branches returns 404`, () => {
+  const earl = `/api/${apiVersion}/databases/nonexistent_owner/nonexistent_database/branches`;
+  it("gets a 404 response from the API", () => {
+    cy.request({ url: earl, failOnStatusCode: false })
+      .its("status")
+      .should("equal", 404);
+  });
+  it("contains the RFC 9457 problem details in the response body", () => {
+    cy.request({ url: earl, failOnStatusCode: false })
+      .its("body.status")
+      .should("equal", 404);
+    cy.request({ url: earl, failOnStatusCode: false })
+      .its("body.code")
+      .should("equal", "NOT_FOUND");
+    cy.request({ url: earl, failOnStatusCode: false })
+      .its("body.detail")
+      .should("equal", "no such repository");
+  });
+});

--- a/cypress/e2e/dolthub/publicPaths/apiV2/database.spec.ts
+++ b/cypress/e2e/dolthub/publicPaths/apiV2/database.spec.ts
@@ -1,0 +1,50 @@
+export {};
+
+const apiVersion = "v2";
+const repoOwner = "automated_testing";
+const repoName = "corona-virus";
+
+describe(`GET /${repoOwner}/${repoName} returns database metadata`, () => {
+  const earl = `/api/${apiVersion}/databases/${repoOwner}/${repoName}`;
+  it("gets a success response from the API", () => {
+    cy.request({ url: earl }).its("status").should("equal", 200);
+  });
+  it("contains the correct database metadata in the response body", () => {
+    cy.request({ url: earl }).its("body.data.owner").should("equal", repoOwner);
+    cy.request({ url: earl }).its("body.data.name").should("equal", repoName);
+    cy.request({ url: earl })
+      .its("body.data.visibility")
+      .should("equal", "public");
+  });
+  it("contains fork network metadata since this database is a fork", () => {
+    cy.request({ url: earl })
+      .its("body.data.parent")
+      .should("deep.equal", { owner: "dolthub", name: repoName });
+    cy.request({ url: earl })
+      .its("body.data.network_root")
+      .should("deep.equal", { owner: "dolthub", name: repoName });
+    cy.request({ url: earl })
+      .its("body.data.fork_network_count")
+      .should("be.a", "number");
+  });
+});
+
+describe(`GET /nonexistent_owner/nonexistent_database returns 404`, () => {
+  const earl = `/api/${apiVersion}/databases/nonexistent_owner/nonexistent_database`;
+  it("gets a 404 response from the API", () => {
+    cy.request({ url: earl, failOnStatusCode: false })
+      .its("status")
+      .should("equal", 404);
+  });
+  it("contains the RFC 9457 problem details in the response body", () => {
+    cy.request({ url: earl, failOnStatusCode: false })
+      .its("body.status")
+      .should("equal", 404);
+    cy.request({ url: earl, failOnStatusCode: false })
+      .its("body.code")
+      .should("equal", "NOT_FOUND");
+    cy.request({ url: earl, failOnStatusCode: false })
+      .its("body.detail")
+      .should("equal", "no such repository");
+  });
+});

--- a/cypress/e2e/dolthub/publicPaths/apiV2/forks.spec.ts
+++ b/cypress/e2e/dolthub/publicPaths/apiV2/forks.spec.ts
@@ -1,0 +1,35 @@
+export {};
+
+const apiVersion = "v2";
+const repoOwner = "automated_testing";
+const repoName = "corona-virus";
+
+describe(`GET /${repoOwner}/${repoName}/forks returns the direct fork children`, () => {
+  const earl = `/api/${apiVersion}/databases/${repoOwner}/${repoName}/forks`;
+  it("gets a success response from the API", () => {
+    cy.request({ url: earl }).its("status").should("equal", 200);
+  });
+  it("contains an array, empty since this database has no forks of its own", () => {
+    cy.request({ url: earl }).its("body.data").should("deep.equal", []);
+  });
+});
+
+describe(`GET /nonexistent_owner/nonexistent_database/forks returns 404`, () => {
+  const earl = `/api/${apiVersion}/databases/nonexistent_owner/nonexistent_database/forks`;
+  it("gets a 404 response from the API", () => {
+    cy.request({ url: earl, failOnStatusCode: false })
+      .its("status")
+      .should("equal", 404);
+  });
+  it("contains the RFC 9457 problem details in the response body", () => {
+    cy.request({ url: earl, failOnStatusCode: false })
+      .its("body.status")
+      .should("equal", 404);
+    cy.request({ url: earl, failOnStatusCode: false })
+      .its("body.code")
+      .should("equal", "NOT_FOUND");
+    cy.request({ url: earl, failOnStatusCode: false })
+      .its("body.detail")
+      .should("equal", "no such repository");
+  });
+});

--- a/cypress/e2e/dolthub/publicPaths/apiV2/operations.spec.ts
+++ b/cypress/e2e/dolthub/publicPaths/apiV2/operations.spec.ts
@@ -1,0 +1,47 @@
+export {};
+
+const apiVersion = "v2";
+const repoOwner = "automated_testing";
+const repoName = "corona-virus";
+
+describe(`GET /${repoOwner}/${repoName}/operations returns the database's async operations`, () => {
+  const earl = `/api/${apiVersion}/databases/${repoOwner}/${repoName}/operations`;
+  it("gets a success response from the API", () => {
+    cy.request({ url: earl }).its("status").should("equal", 200);
+  });
+  it("contains an array of operations", () => {
+    cy.request({ url: earl })
+      .its("body.data")
+      .should("be.an", "array")
+      .and("have.length.above", 0);
+  });
+  it("contains operations with the expected fields", () => {
+    cy.request({ url: earl })
+      .its("body.data")
+      .then(operations => {
+        expect(operations[0]).to.include.keys([
+          "id",
+          "type",
+          "status",
+          "created_at",
+        ]);
+      });
+  });
+});
+
+describe(`GET /nonexistent_owner/nonexistent_database/operations returns 404`, () => {
+  const earl = `/api/${apiVersion}/databases/nonexistent_owner/nonexistent_database/operations`;
+  it("gets a 404 response from the API", () => {
+    cy.request({ url: earl, failOnStatusCode: false })
+      .its("status")
+      .should("equal", 404);
+  });
+  it("contains the RFC 9457 problem details in the response body", () => {
+    cy.request({ url: earl, failOnStatusCode: false })
+      .its("body.code")
+      .should("equal", "NOT_FOUND");
+    cy.request({ url: earl, failOnStatusCode: false })
+      .its("body.detail")
+      .should("equal", "no such repository");
+  });
+});

--- a/cypress/e2e/dolthub/publicPaths/apiV2/pull.spec.ts
+++ b/cypress/e2e/dolthub/publicPaths/apiV2/pull.spec.ts
@@ -1,0 +1,71 @@
+export {};
+
+const apiVersion = "v2";
+const repoOwner = "automated_testing";
+const repoName = "corona-virus";
+const pullNumber = "1";
+
+describe(`GET /${repoOwner}/${repoName}/pulls/${pullNumber} returns pull request details`, () => {
+  const earl = `/api/${apiVersion}/databases/${repoOwner}/${repoName}/pulls/${pullNumber}`;
+  it("gets a success response from the API", () => {
+    cy.request({ url: earl }).its("status").should("equal", 200);
+  });
+  it("contains the correct pull request details", () => {
+    cy.request({ url: earl }).its("body.data.pull_number").should("equal", 1);
+    cy.request({ url: earl }).its("body.data.state").should("equal", "merged");
+    cy.request({ url: earl })
+      .its("body.data.title")
+      .should("equal", "Crowdsourced");
+    cy.request({ url: earl })
+      .its("body.data.creator")
+      .should("equal", "cypresstesting");
+  });
+  it("contains structured from_branch and to_branch references", () => {
+    cy.request({ url: earl })
+      .its("body.data.from_branch")
+      .should("deep.equal", {
+        database: { owner: repoOwner, name: repoName },
+        branch_name: "crowdsource-case-details",
+      });
+    cy.request({ url: earl })
+      .its("body.data.to_branch")
+      .should("deep.equal", {
+        database: { owner: repoOwner, name: repoName },
+        branch_name: "master",
+      });
+  });
+});
+
+describe(`GET /${repoOwner}/${repoName}/pulls/99999 returns 404`, () => {
+  const earl = `/api/${apiVersion}/databases/${repoOwner}/${repoName}/pulls/99999`;
+  it("gets a 404 response from the API", () => {
+    cy.request({ url: earl, failOnStatusCode: false })
+      .its("status")
+      .should("equal", 404);
+  });
+  it("contains the RFC 9457 problem details in the response body", () => {
+    cy.request({ url: earl, failOnStatusCode: false })
+      .its("body.code")
+      .should("equal", "NOT_FOUND");
+    cy.request({ url: earl, failOnStatusCode: false })
+      .its("body.detail")
+      .should("equal", "no such pull");
+  });
+});
+
+describe(`GET /nonexistent_owner/nonexistent_database/pulls/${pullNumber} returns 404`, () => {
+  const earl = `/api/${apiVersion}/databases/nonexistent_owner/nonexistent_database/pulls/${pullNumber}`;
+  it("gets a 404 response from the API", () => {
+    cy.request({ url: earl, failOnStatusCode: false })
+      .its("status")
+      .should("equal", 404);
+  });
+  it("contains the RFC 9457 problem details in the response body", () => {
+    cy.request({ url: earl, failOnStatusCode: false })
+      .its("body.code")
+      .should("equal", "NOT_FOUND");
+    cy.request({ url: earl, failOnStatusCode: false })
+      .its("body.detail")
+      .should("equal", "no such repository");
+  });
+});

--- a/cypress/e2e/dolthub/publicPaths/apiV2/pullComments.spec.ts
+++ b/cypress/e2e/dolthub/publicPaths/apiV2/pullComments.spec.ts
@@ -1,0 +1,33 @@
+export {};
+
+const apiVersion = "v2";
+const repoOwner = "automated_testing";
+const repoName = "corona-virus";
+const pullNumber = "1";
+
+describe(`GET /${repoOwner}/${repoName}/pulls/${pullNumber}/comments returns pull request comments`, () => {
+  const earl = `/api/${apiVersion}/databases/${repoOwner}/${repoName}/pulls/${pullNumber}/comments`;
+  it("gets a success response from the API", () => {
+    cy.request({ url: earl }).its("status").should("equal", 200);
+  });
+  it("contains an array of comments", () => {
+    cy.request({ url: earl }).its("body.data").should("be.an", "array");
+  });
+});
+
+describe(`GET /${repoOwner}/${repoName}/pulls/99999/comments returns 404`, () => {
+  const earl = `/api/${apiVersion}/databases/${repoOwner}/${repoName}/pulls/99999/comments`;
+  it("gets a 404 response from the API", () => {
+    cy.request({ url: earl, failOnStatusCode: false })
+      .its("status")
+      .should("equal", 404);
+  });
+  it("contains the RFC 9457 problem details in the response body", () => {
+    cy.request({ url: earl, failOnStatusCode: false })
+      .its("body.code")
+      .should("equal", "NOT_FOUND");
+    cy.request({ url: earl, failOnStatusCode: false })
+      .its("body.detail")
+      .should("equal", "no such pull");
+  });
+});

--- a/cypress/e2e/dolthub/publicPaths/apiV2/pulls.spec.ts
+++ b/cypress/e2e/dolthub/publicPaths/apiV2/pulls.spec.ts
@@ -1,0 +1,51 @@
+export {};
+
+const apiVersion = "v2";
+const repoOwner = "automated_testing";
+const repoName = "corona-virus";
+
+describe(`GET /${repoOwner}/${repoName}/pulls returns pull requests`, () => {
+  const earl = `/api/${apiVersion}/databases/${repoOwner}/${repoName}/pulls`;
+  it("gets a success response from the API", () => {
+    cy.request({ url: earl }).its("status").should("equal", 200);
+  });
+  it("contains an array of pull requests", () => {
+    cy.request({ url: earl })
+      .its("body.data")
+      .should("be.an", "array")
+      .and("have.length.above", 0);
+  });
+  it("contains pull requests with the expected fields", () => {
+    cy.request({ url: earl })
+      .its("body.data")
+      .then(pulls => {
+        expect(pulls[0]).to.include.keys([
+          "pull_number",
+          "title",
+          "state",
+          "creator",
+          "created_at",
+        ]);
+      });
+  });
+});
+
+describe(`GET /nonexistent_owner/nonexistent_database/pulls returns 404`, () => {
+  const earl = `/api/${apiVersion}/databases/nonexistent_owner/nonexistent_database/pulls`;
+  it("gets a 404 response from the API", () => {
+    cy.request({ url: earl, failOnStatusCode: false })
+      .its("status")
+      .should("equal", 404);
+  });
+  it("contains the RFC 9457 problem details in the response body", () => {
+    cy.request({ url: earl, failOnStatusCode: false })
+      .its("body.status")
+      .should("equal", 404);
+    cy.request({ url: earl, failOnStatusCode: false })
+      .its("body.code")
+      .should("equal", "NOT_FOUND");
+    cy.request({ url: earl, failOnStatusCode: false })
+      .its("body.detail")
+      .should("equal", "no such repository");
+  });
+});

--- a/cypress/e2e/dolthub/publicPaths/apiV2/releases.spec.ts
+++ b/cypress/e2e/dolthub/publicPaths/apiV2/releases.spec.ts
@@ -1,0 +1,51 @@
+export {};
+
+const apiVersion = "v2";
+const repoOwner = "automated_testing";
+const repoName = "repo_with_tags_and_branches";
+
+describe(`GET /${repoOwner}/${repoName}/releases returns releases`, () => {
+  const earl = `/api/${apiVersion}/databases/${repoOwner}/${repoName}/releases`;
+  it("gets a success response from the API", () => {
+    cy.request({ url: earl }).its("status").should("equal", 200);
+  });
+  it("contains an array of releases", () => {
+    cy.request({ url: earl })
+      .its("body.data")
+      .should("be.an", "array")
+      .and("have.length.of.at.least", 1);
+  });
+  it("contains releases with the expected fields", () => {
+    cy.request({ url: earl })
+      .its("body.data")
+      .then(releases => {
+        expect(releases[0]).to.include.keys([
+          "tag",
+          "title",
+          "commit_sha",
+          "created_at",
+          "updated_at",
+        ]);
+      });
+  });
+});
+
+describe(`GET /nonexistent_owner/nonexistent_database/releases returns 404`, () => {
+  const earl = `/api/${apiVersion}/databases/nonexistent_owner/nonexistent_database/releases`;
+  it("gets a 404 response from the API", () => {
+    cy.request({ url: earl, failOnStatusCode: false })
+      .its("status")
+      .should("equal", 404);
+  });
+  it("contains the RFC 9457 problem details in the response body", () => {
+    cy.request({ url: earl, failOnStatusCode: false })
+      .its("body.status")
+      .should("equal", 404);
+    cy.request({ url: earl, failOnStatusCode: false })
+      .its("body.code")
+      .should("equal", "NOT_FOUND");
+    cy.request({ url: earl, failOnStatusCode: false })
+      .its("body.detail")
+      .should("equal", "no such repository");
+  });
+});

--- a/cypress/e2e/dolthub/publicPaths/apiV2/sql.spec.ts
+++ b/cypress/e2e/dolthub/publicPaths/apiV2/sql.spec.ts
@@ -79,7 +79,9 @@ describe(`POST /${repoOwner}/${repoName}/sql runs the same read-only query as th
         body: { ref: defaultBranch, q: defaultQuery },
       }).then(postResp => {
         expect(postResp.body.data.status).to.equal(getResp.body.data.status);
-        expect(postResp.body.data.columns).to.deep.equal(getResp.body.data.columns);
+        expect(postResp.body.data.columns).to.deep.equal(
+          getResp.body.data.columns,
+        );
         expect(postResp.body.data.rows).to.deep.equal(getResp.body.data.rows);
       });
     });

--- a/cypress/e2e/dolthub/publicPaths/apiV2/sql.spec.ts
+++ b/cypress/e2e/dolthub/publicPaths/apiV2/sql.spec.ts
@@ -70,13 +70,19 @@ describe(`POST /${repoOwner}/${repoName}/sql runs the same read-only query as th
       .should("equal", 200);
   });
   it("contains the same result as the GET variant", () => {
-    cy.request({
-      method: "POST",
-      url: earl,
-      body: { ref: defaultBranch, q: defaultQuery },
-    })
-      .its("body.data.status")
-      .should("equal", "success");
+    const getUrl = `${earl}?ref=${defaultBranch}&q=${encodeURIComponent(defaultQuery)}`;
+
+    cy.request({ url: getUrl }).then(getResp => {
+      cy.request({
+        method: "POST",
+        url: earl,
+        body: { ref: defaultBranch, q: defaultQuery },
+      }).then(postResp => {
+        expect(postResp.body.data.status).to.equal(getResp.body.data.status);
+        expect(postResp.body.data.columns).to.deep.equal(getResp.body.data.columns);
+        expect(postResp.body.data.rows).to.deep.equal(getResp.body.data.rows);
+      });
+    });
   });
 });
 

--- a/cypress/e2e/dolthub/publicPaths/apiV2/sql.spec.ts
+++ b/cypress/e2e/dolthub/publicPaths/apiV2/sql.spec.ts
@@ -1,0 +1,129 @@
+export {};
+
+const apiVersion = "v2";
+const repoOwner = "automated_testing";
+const repoName = "corona-virus";
+const defaultBranch = "master";
+const defaultQuery = "SHOW TABLES;";
+const selectQuery = "SELECT * FROM `places` ORDER BY place_id ASC LIMIT 5;";
+const badQuery = "heatdome";
+
+describe(`GET /${repoOwner}/${repoName}/sql runs a read-only query`, () => {
+  const earl = `/api/${apiVersion}/databases/${repoOwner}/${repoName}/sql?ref=${defaultBranch}&q=${encodeURIComponent(
+    defaultQuery,
+  )}`;
+  it("gets a success response from the API", () => {
+    cy.request({ url: earl }).its("status").should("equal", 200);
+  });
+  it("contains the correct query result status in the response body", () => {
+    cy.request({ url: earl })
+      .its("body.data.status")
+      .should("equal", "success");
+  });
+  it("contains the correct query result columns in the response body", () => {
+    cy.request({ url: earl })
+      .its("body.data.columns")
+      .then(columns => {
+        expect(columns).to.have.length(1);
+        expect(columns[0]).to.include({ name: "Tables_in_corona-virus" });
+      });
+  });
+  it("contains the correct query result rows in the response body", () => {
+    cy.request({ url: earl })
+      .its("body.data.rows")
+      .should("deep.include", ["places"])
+      .and("deep.include", ["case_details"]);
+  });
+});
+
+describe(`GET /${repoOwner}/${repoName}/sql runs a SELECT query`, () => {
+  const earl = `/api/${apiVersion}/databases/${repoOwner}/${repoName}/sql?ref=${defaultBranch}&q=${encodeURIComponent(
+    selectQuery,
+  )}`;
+  it("contains the correct query result columns and rows in the response body", () => {
+    cy.request({ url: earl })
+      .its("body.data.columns")
+      .then(columns => {
+        expect(
+          columns.map((column: { name: string }) => column.name),
+        ).to.deep.equal([
+          "place_id",
+          "province_state",
+          "country_region",
+          "latitude",
+          "longitude",
+        ]);
+      });
+    cy.request({ url: earl }).its("body.data.rows").should("have.length", 5);
+  });
+});
+
+describe(`POST /${repoOwner}/${repoName}/sql runs the same read-only query as the GET variant`, () => {
+  const earl = `/api/${apiVersion}/databases/${repoOwner}/${repoName}/sql`;
+  it("gets a success response from the API", () => {
+    cy.request({
+      method: "POST",
+      url: earl,
+      body: { ref: defaultBranch, q: defaultQuery },
+    })
+      .its("status")
+      .should("equal", 200);
+  });
+  it("contains the same result as the GET variant", () => {
+    cy.request({
+      method: "POST",
+      url: earl,
+      body: { ref: defaultBranch, q: defaultQuery },
+    })
+      .its("body.data.status")
+      .should("equal", "success");
+  });
+});
+
+describe(`GET /${repoOwner}/${repoName}/sql returns a query-level error for an invalid query`, () => {
+  const earl = `/api/${apiVersion}/databases/${repoOwner}/${repoName}/sql?ref=${defaultBranch}&q=${encodeURIComponent(
+    badQuery,
+  )}`;
+  it("gets a 200 response from the API since this is a query-level, not transport-level, failure", () => {
+    cy.request({ url: earl }).its("status").should("equal", 200);
+  });
+  it("contains the correct error status and message in the response body", () => {
+    cy.request({ url: earl }).its("body.data.status").should("equal", "error");
+    cy.request({ url: earl })
+      .its("body.data.message")
+      .should("contain", "query error");
+  });
+});
+
+describe(`GET /${repoOwner}/${repoName}/sql without required params returns 400`, () => {
+  const earl = `/api/${apiVersion}/databases/${repoOwner}/${repoName}/sql`;
+  it("gets a 400 response from the API", () => {
+    cy.request({ url: earl, failOnStatusCode: false })
+      .its("status")
+      .should("equal", 400);
+  });
+  it("contains the RFC 9457 problem details in the response body", () => {
+    cy.request({ url: earl, failOnStatusCode: false })
+      .its("body.code")
+      .should("equal", "VALIDATION_FAILED");
+  });
+});
+
+describe(`GET /nonexistent_owner/nonexistent_database/sql returns 404`, () => {
+  const earl = `/api/${apiVersion}/databases/nonexistent_owner/nonexistent_database/sql?ref=${defaultBranch}&q=${encodeURIComponent(
+    defaultQuery,
+  )}`;
+  it("gets a 404 response from the API", () => {
+    cy.request({ url: earl, failOnStatusCode: false })
+      .its("status")
+      .should("equal", 404);
+  });
+  it("contains the RFC 9457 problem details in the response body", () => {
+    cy.request({ url: earl, failOnStatusCode: false })
+      .its("body.code")
+      .should("equal", "NOT_FOUND");
+    cy.request({ url: earl, failOnStatusCode: false })
+      .its("body.detail")
+      .should("equal", "no such repository");
+  });
+});

--- a/cypress/e2e/dolthub/publicPaths/apiV2/tags.spec.ts
+++ b/cypress/e2e/dolthub/publicPaths/apiV2/tags.spec.ts
@@ -1,0 +1,45 @@
+export {};
+
+const apiVersion = "v2";
+const repoOwner = "automated_testing";
+const repoName = "repo_with_tags_and_branches";
+
+describe(`GET /${repoOwner}/${repoName}/tags returns tags`, () => {
+  const earl = `/api/${apiVersion}/databases/${repoOwner}/${repoName}/tags`;
+  it("gets a success response from the API", () => {
+    cy.request({ url: earl }).its("status").should("equal", 200);
+  });
+  it("contains an array of tags", () => {
+    cy.request({ url: earl })
+      .its("body.data")
+      .should("be.an", "array")
+      .and("have.length.above", 10);
+  });
+  it("contains tags with the expected fields", () => {
+    cy.request({ url: earl })
+      .its("body.data")
+      .then(tags => {
+        expect(tags[0]).to.include.keys(["name", "commit_sha", "tagged_at"]);
+      });
+  });
+});
+
+describe(`GET /nonexistent_owner/nonexistent_database/tags returns 404`, () => {
+  const earl = `/api/${apiVersion}/databases/nonexistent_owner/nonexistent_database/tags`;
+  it("gets a 404 response from the API", () => {
+    cy.request({ url: earl, failOnStatusCode: false })
+      .its("status")
+      .should("equal", 404);
+  });
+  it("contains the RFC 9457 problem details in the response body", () => {
+    cy.request({ url: earl, failOnStatusCode: false })
+      .its("body.status")
+      .should("equal", 404);
+    cy.request({ url: earl, failOnStatusCode: false })
+      .its("body.code")
+      .should("equal", "NOT_FOUND");
+    cy.request({ url: earl, failOnStatusCode: false })
+      .its("body.detail")
+      .should("equal", "no such repository");
+  });
+});


### PR DESCRIPTION
## Summary
- Adds Cypress tests for the DoltHub v2 API (per [dolthub/docs-2#121](https://github.com/dolthub/docs-2/pull/121)), starting with endpoints that don't require authentication.
- Tests run against real `automated_testing` org repos on `https://www.dolthub.com` (the default `baseUrl`).
- New directory `cypress/e2e/dolthub/publicPaths/apiV2/`, mirroring the existing `api/` (v1alpha1) test layout:
  - `database.spec.ts` — `GET /databases/{owner}/{db}`
  - `branches.spec.ts` — `GET .../branches`
  - `tags.spec.ts` — `GET .../tags`
  - `forks.spec.ts` — `GET .../forks`
  - `releases.spec.ts` — `GET .../releases`
  - `sql.spec.ts` — `GET`/`POST .../sql`
  - `pulls.spec.ts` — `GET .../pulls`
  - `pull.spec.ts` — `GET .../pulls/{n}`
  - `pullComments.spec.ts` — `GET .../pulls/{n}/comments`
  - `operations.spec.ts` — `GET .../operations`
- Each spec covers a happy path plus the RFC 9457 `Problem` error shape for a nonexistent database/pull.
- `GET /user` and `GET /operations/{id}` are intentionally excluded — verified live that both require auth (401) despite being read-only GETs.

## Test plan
- [x] `yarn cy-run --spec "cypress/e2e/dolthub/publicPaths/apiV2/*.spec.ts"` — 58/58 passing against prod
- [x] `yarn tsc -b`
- [x] `yarn eslint`
- [x] `yarn prettier --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)