### PR TITLE
Bump undici resolution to 6.28.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,6 +65,6 @@
   "resolutions": {
     "fast-xml-parser@npm:5.2.5": "5.5.6",
     "tar": "7.5.11",
-    "undici": "6.24.0"
+    "undici": "6.28.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7110,10 +7110,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"undici@npm:6.24.0":
-  version: 6.24.0
-  resolution: "undici@npm:6.24.0"
-  checksum: 10/fdb636cd583c9f12736b32ef088a2d9da9398fc0b80805b519137b3d8e5fcaa6e4c25630414df678aa9912e7f9c1c49911645592da07abda2e1094398175e9da
+"undici@npm:6.28.0":
+  version: 6.28.0
+  resolution: "undici@npm:6.28.0"
+  checksum: 10/672a7a53bd1f6c80edb73b357ab36e98ef9e474024c442aab2b8ea2bc32f1103cab05525c78661ae724f3e1340e23d03efb9730fba28e76218ab0ec52e15d75a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Resolves all 7 open Dependabot alerts (1 high, 4 medium, 2 low), which were all against `undici < 6.28.0`.

`undici` isn't a direct dependency — it comes in transitively via `@actions/http-client` (`^5.28.5` and `^6.23.0`). But a `resolutions` entry in `package.json` pinned it to `6.24.0`, which held every dependent on the vulnerable release. Bumping that pin to `6.28.0` (latest 6.x, and the first patched version for all 7 advisories) clears them.

## Changes
- `package.json`: `undici` resolution `6.24.0` → `6.28.0`
- `yarn.lock`: corresponding entry updated

## Verification
- `yarn install` succeeds
- `yarn ci` (prettier + tsc + eslint) passes — 0 errors, 4 pre-existing lint warnings unchanged
- `yarn.lock` contains a single `undici@npm:6.28.0` entry, no vulnerable copies remain

The peer-dependency warnings from `yarn install` are pre-existing and unrelated (Babel 7/8 and eslint-config-airbnb version ranges).

🤖 Generated with [Claude Code](https://claude.com/claude-code)